### PR TITLE
Update README to include details about updating Podfile for React dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ Add the following to your Podfile:
 pod "react-native-heap", path: "../node_modules/@heap/react-native-heap"
 ```
 
+If your Podfile does not specify the path to your local React pod, you should add that (and any other necessary subspecs) to your Podfile. For example:
+
+```ruby
+pod 'React', :path => '../node_modules/react-native', :subspecs => [
+  'Core',
+  'CxxBridge', # Include this for RN >= 0.47
+  'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
+  'RCTText',
+  'RCTNetwork',
+  'RCTWebSocket', # Needed for debugging
+  'RCTAnimation', # Needed for FlatList and animations running on native UI thread
+  # Add any other subspecs you want to use in your project
+]
+
+# Explicitly include Yoga if you are using RN >= 0.42.0
+pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+```
+
 Then run:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Heap.track('signed-up', { isPaid: true, amount: 20 });
 
 ### iOS Build Issues
 **Build failures due to file not found errors**
+
 Build failures may occur if your Podfile does not specify the path to your local React pod, which should be added (and any other necessary subspecs) to your Podfile. You can find more information (and an example) in the [official React Native docs](https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies). Failing to do so will result in the `pod install` step installing an additional React dependency (version 0.11 by default). You can confirm if correct React version is being used in Podfile.lock.
 
 

--- a/README.md
+++ b/README.md
@@ -24,23 +24,6 @@ Add the following to your Podfile:
 pod "react-native-heap", path: "../node_modules/@heap/react-native-heap"
 ```
 
-If your Podfile does not specify the path to your local React pod, you should add that (and any other necessary subspecs) to your Podfile. For example:
-
-```ruby
-pod 'React', :path => '../node_modules/react-native', :subspecs => [
-  'Core',
-  'CxxBridge', # Include this for RN >= 0.47
-  'DevSupport', # Include this to enable In-App Devmenu if RN >= 0.43
-  'RCTText',
-  'RCTNetwork',
-  'RCTWebSocket', # Needed for debugging
-  'RCTAnimation', # Needed for FlatList and animations running on native UI thread
-  # Add any other subspecs you want to use in your project
-]
-
-# Explicitly include Yoga if you are using RN >= 0.42.0
-pod 'yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
-```
 
 Then run:
 
@@ -117,6 +100,13 @@ Heap.clearEventProperties();
 // To track an event, use:
 Heap.track('signed-up', { isPaid: true, amount: 20 });
 ```
+
+## Troubleshooting
+
+### iOS Build Issues
+**Build failures due to file not found errors**
+Build failures may occur if your Podfile does not specify the path to your local React pod, which should be added (and any other necessary subspecs) to your Podfile. You can find more information (and an example) in the [official React Native docs](https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies). Failing to do so will result in the `pod install` step installing an additional React dependency (version 0.11 by default). You can confirm if correct React version is being used in Podfile.lock.
+
 
 ## Acknowledgements
 


### PR DESCRIPTION
Our default podspec pulls in React 0.11, which can cause build failures if React isn't already overridden in the target project's Podfile.