### PR TITLE
Upgrade Heap dependency to 5.1.0.

### DIFF
--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.platform = :ios, "8.0"
 
   s.dependency "React"
-  s.dependency "Heap", "5.0.8"
+  s.dependency "Heap", "5.1.0"
 end


### PR DESCRIPTION
This allows us to send events to localhost, which we use for testing.