### PR TITLE
Upgrade Android SDK dependency for tests

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.heapanalytics.android:heap-android-client:0.8.1'
+    implementation 'com.heapanalytics.android:heap-android-client:0.8.3'
 }


### PR DESCRIPTION
Upgrade the Heap Android SDK dependency version from `0.8.1` to `0.8.3` to allow endpoints to be set through a build config during testing.