### PR TITLE
Ignore 'View' components in hierarchy

### DIFF
--- a/js/Heap.js
+++ b/js/Heap.js
@@ -99,6 +99,11 @@ const getFiberNodeComponentHierarchy = currNode => {
 
   const elementName =
     currNode.elementType.displayName || currNode.elementType.name;
+
+  if (elementName === 'View') {
+    return getFiberNodeComponentHierarchy(currNode.return);
+  }
+
   const propsString = extractProps(
     elementName,
     currNode.stateNode,

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -100,6 +100,8 @@ const getFiberNodeComponentHierarchy = currNode => {
   const elementName =
     currNode.elementType.displayName || currNode.elementType.name;
 
+  // In dev builds, 'View' components remain in the fiber tree, but don't provide any useful
+  // information, so exclude these from the hierarchy.
   if (elementName === 'View') {
     return getFiberNodeComponentHierarchy(currNode.return);
   }


### PR DESCRIPTION
`View` components show up in the hierarchy in dev builds, but not prod builds, and aren't actually relevant to the overall component hierarchy.  Leave `View`s out of the hierarchy.