### PR TITLE
Get component name from 'type' instead of 'elementType'

### DIFF
--- a/js/Heap.js
+++ b/js/Heap.js
@@ -122,15 +122,15 @@ const getFiberNodeComponentHierarchy = currNode => {
   // Skip components we don't care about.
   // :TODO: (jmtaber129): Skip components with names/display names like 'View' and '_class'.
   if (
-    currNode.elementType === 'RCTView' ||
-    currNode.elementType === null ||
-    !(currNode.elementType.displayName || currNode.elementType.name)
+    currNode.type === 'RCTView' ||
+    currNode.type === null ||
+    !(currNode.type.displayName || currNode.type.name)
   ) {
     return getFiberNodeComponentHierarchy(currNode.return);
   }
 
   const elementName =
-    currNode.elementType.displayName || currNode.elementType.name;
+    currNode.type.displayName || currNode.type.name;
 
   // In dev builds, 'View' components remain in the fiber tree, but don't provide any useful
   // information, so exclude these from the hierarchy.


### PR DESCRIPTION
It seems like `elementType` isn't present on fiberNodes for certain versions and/or configs, but `type` does seem to be present regardless of whether `elementType` is present.