### PR TITLE
Remove react-native-package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "babel-template": "^6.26.0",
     "babel-types": "^6.26.0",
     "flat": "^4.1.0",
-    "lodash.pick": "^4.4.0",
-    "react-native-package": "^2.5.0"
+    "lodash.pick": "^4.4.0"
   },
   "peerDependencies": {
     "react-native": "x.x"


### PR DESCRIPTION
The main reason this dependency was originally included was to restrict the platforms where rnheap would run to only iOS (since android wasn't implemented).  Now that android is also supported, we can remove this dependency.