### PR TITLE
Add babel-plugin-add-react-displayname as package dependency

### DIFF
--- a/examples/TestDriver/package-lock.json
+++ b/examples/TestDriver/package-lock.json
@@ -856,14 +856,14 @@
     },
     "@heap/react-native-heap": {
       "version": "file:heap-react-native-heap-0.1.2.tgz",
-      "integrity": "sha512-CtBbJqaaVwGMVfOgd9TA1DpUOI88eiLaXgS3JqXBY3/LlYcdRzKiji1+s+xgykVB69FzMCZM7FFiwZoofNR1bg==",
+      "integrity": "sha512-v1XKo2i6aMo8/oRwyG+sL7FpZwqPiBtUL4GnMDyaYOkdLdePC8jz0CCPurv1Z8byj9ApiL5dbd3mVIf8RK+aug==",
       "requires": {
         "@babel/core": "^7.2.2",
+        "babel-plugin-add-react-displayname": "0.0.5",
         "babel-template": "^6.26.0",
         "babel-types": "^6.26.0",
         "flat": "^4.1.0",
-        "lodash.pick": "^4.4.0",
-        "react-native-package": "^2.5.0"
+        "lodash.pick": "^4.4.0"
       }
     },
     "abab": {
@@ -8207,32 +8207,6 @@
         "yargs": "^9.0.0"
       }
     },
-    "react-native-module-check": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/react-native-module-check/-/react-native-module-check-2.6.2.tgz",
-      "integrity": "sha512-Thm+dfELhc7FZ86Hsoxc25gtQa65C+Z9BXhi9rxDcnRKwCJ+DoCED5jdfvFm8g03WzYkqGojncZ1lNZ+c/sfUg==",
-      "requires": {
-        "invariant": "^2.2.2",
-        "warning": "^3.0.0"
-      }
-    },
-    "react-native-module-guard": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/react-native-module-guard/-/react-native-module-guard-2.6.2.tgz",
-      "integrity": "sha512-jXY25yZVYf2VpYU/vC7lsZ4b/9avP7otrZVQ/OQRf39KasxRYaIZTmR69LYlguM7x9Vo3VXe27zor9fibwfi1A==",
-      "requires": {
-        "warning": "^3.0.0"
-      }
-    },
-    "react-native-package": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/react-native-package/-/react-native-package-2.6.2.tgz",
-      "integrity": "sha512-Ic8jFJI/CBgxAOGA/iCPkM8nFj6tMstGUIiUIWP4JlBlod0EtVQ+ch8y61XFdfBM7AhUdYQ77HplJ7GgtF1JxQ==",
-      "requires": {
-        "react-native-module-check": "^2.6.2",
-        "react-native-module-guard": "^2.6.2"
-      }
-    },
     "react-proxy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
@@ -10040,14 +10014,6 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watch": {

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@heap/react-native-heap": "heap-react-native-heap-0.1.2.tgz",
-    "babel-plugin-add-react-displayname": "0.0.5",
     "react": "16.6.1",
     "react-native": "0.57.5",
     "react-redux": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "babel-template": "^6.26.0",
     "babel-types": "^6.26.0",
     "flat": "^4.1.0",
-    "lodash.pick": "^4.4.0"
+    "lodash.pick": "^4.4.0",
+    "babel-plugin-add-react-displayname": "0.0.5"
   },
   "peerDependencies": {
     "react-native": "x.x"


### PR DESCRIPTION
`babel-plugin-add-react-displayname` needs to be in an app's `.babelrc` in order for hierarchies to include meaningful component names, but it's not currently a package dependency.  This means that a dev would need to `npm install babel-plugin-add-react-displayname` themselves in order to get autotrack.

Instead, make `babel-plugin-add-react-displayname` a dependency of the `react-native-heap` package.