### PR TITLE
DO NOT MERGE: POC React Navigation autotrack

### DIFF
--- a/examples/TestDriver/App.js
+++ b/examples/TestDriver/App.js
@@ -1,14 +1,87 @@
 import React from "react";
 import { Provider } from "react-redux";
+import { View,Text,Button, StyleSheet } from "react-native";
+import Heap from '@heap/react-native-heap';
+import { createStackNavigator, createBottomTabNavigator, createDrawerNavigator, createAppContainer } from "react-navigation";
+
 import { store } from "./src/reduxElements";
 import MainScreen from "./src/mainScreen";
+
+class OtherScreen extends React.Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Button onPress={() => {console.log('yolo'); this.props.navigation.navigate('MyModal')}} title={'press me'}/>
+      </View>
+    );
+  }
+}
+
+const StackNav = createStackNavigator({
+  Original: {
+    screen: MainScreen,
+  },
+  Other: {
+    screen: OtherScreen,
+  }
+});
+
+const AppNavigator = createBottomTabNavigator({
+// const AppNavigator = createDrawerNavigator({
+  Main: {
+    screen: StackNav,
+  },
+  AppOther: {
+    screen: OtherScreen,
+  }
+});
+
+class ModalScreen extends React.Component {
+  render() {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Text style={{ fontSize: 30 }}>This is a modal!</Text>
+        <Button
+          onPress={() => {this.props.navigation.goBack(); console.log(AppNavigator)}}
+          title="Dismiss"
+        />
+      </View>
+    );
+  }
+}
+
+const TopNavigator = createStackNavigator(
+  {
+    Main: {
+      screen: AppNavigator,
+    },
+    MyModal: {
+      screen: ModalScreen,
+    },
+  },
+  {
+    mode: 'modal',
+    headerMode: 'none',
+  }
+);
+
+const AppContainer = Heap.withHeapNavigationAutotrack(createAppContainer(TopNavigator));
 
 export default class App extends React.Component {
   render() {
     return (
       <Provider store={store}>
-        <MainScreen />
+        <AppContainer/>
       </Provider>
     );
   }
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#F5FCFF"
+  }
+});

--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -146,6 +146,8 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-gesture-handler')
+    compile project(':@heap_react-native-heap')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules

--- a/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
+++ b/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
@@ -3,6 +3,8 @@ package com.testdriver;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
+import com.heapanalytics.reactnative.RNHeapLibraryPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -24,6 +26,8 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
               new MainReactPackage(),
+            new RNGestureHandlerPackage(),
+            new RNHeapLibraryPackage(),
               new RNHeapLibraryPackage()
       );
     }

--- a/examples/TestDriver/android/settings.gradle
+++ b/examples/TestDriver/android/settings.gradle
@@ -1,4 +1,8 @@
 rootProject.name = 'TestDriver'
+include ':react-native-gesture-handler'
+project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
+include ':@heap_react-native-heap'
+project(':@heap_react-native-heap').projectDir = new File(rootProject.projectDir, '../node_modules/@heap/react-native-heap/android')
 
 include ':app'
 

--- a/examples/TestDriver/ios/Podfile
+++ b/examples/TestDriver/ios/Podfile
@@ -31,6 +31,8 @@ target "TestDriver" do
 
   pod "react-native-heap", path: "../node_modules/@heap/react-native-heap"
 
+  pod 'RNGestureHandler', :path => '../node_modules/react-native-gesture-handler'
+
   target "TestDriverTests" do
     inherit! :search_paths
   end

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -57,6 +57,8 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
+  - RNGestureHandler (1.0.15):
+    - React
   - yoga (0.57.5.React)
 
 DEPENDENCIES:
@@ -77,6 +79,7 @@ DEPENDENCIES:
   - React/RCTText (from `../node_modules/react-native`)
   - React/RCTVibration (from `../node_modules/react-native`)
   - React/RCTWebSocket (from `../node_modules/react-native`)
+  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - yoga (from `../node_modules/react-native/ReactCommon/yoga/yoga.podspec`)
 
 SPEC REPOS:
@@ -95,6 +98,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native"
   react-native-heap:
     :path: "../node_modules/@heap/react-native-heap"
+  RNGestureHandler:
+    :path: "../node_modules/react-native-gesture-handler"
   yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga/yoga.podspec"
 
@@ -106,8 +111,9 @@ SPEC CHECKSUMS:
   Heap: 542282698e895bf511429e87e213ad863faabd5d
   React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
   react-native-heap: 720108c6585d0dedcc9fdca9ee336cd4758c3655
+  RNGestureHandler: afde2addc517e85cc97a25bfe119acbee779a7ce
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
-PODFILE CHECKSUM: fcda9e350f1de67f063fca623567dce94a74fd3e
+PODFILE CHECKSUM: 552d41c2899016435b38ff4b7aa16fe120e57790
 
 COCOAPODS: 1.5.3

--- a/examples/TestDriver/ios/TestDriver/AppDelegate.m
+++ b/examples/TestDriver/ios/TestDriver/AppDelegate.m
@@ -33,10 +33,10 @@
   [self.window makeKeyAndVisible];
 
   // Send events to local collector.
-  SEL setRootUrlSelector = @selector(setRootUrl:);
-  if ([[Heap class] respondsToSelector:setRootUrlSelector]) {
-    [[Heap class] performSelector:setRootUrlSelector withObject:@"http://localhost:3000"];
-  }
+//  SEL setRootUrlSelector = @selector(setRootUrl:);
+//  if ([[Heap class] respondsToSelector:setRootUrlSelector]) {
+//    [[Heap class] performSelector:setRootUrlSelector withObject:@"http://localhost:3000"];
+//  }
 
   return YES;
 }

--- a/examples/TestDriver/package-lock.json
+++ b/examples/TestDriver/package-lock.json
@@ -866,6 +866,54 @@
         "lodash.pick": "^4.4.0"
       }
     },
+    "@react-navigation/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-vVPUIpCWO3VKVvE5zYDDR/lOy5hHvRm60rQAHTF19vmt3Jqnbs3qqgYovfUAnTBm0crGLcuIwzOuprRIhC4bfQ==",
+      "requires": {
+        "create-react-context": "0.2.2",
+        "hoist-non-react-statics": "^3.0.1",
+        "path-to-regexp": "^1.7.0",
+        "query-string": "^6.2.0",
+        "react-is": "^16.5.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "@react-navigation/native": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.1.4.tgz",
+      "integrity": "sha512-Py9+FDgwT1AvQE+NzVtvcaGF5IxLtFu7XxEaDvcnI8LFeOt/CVESdJJW8kgxJuYhQQzgLZagQ2hwz5kU2I7tYg==",
+      "requires": {
+        "hoist-non-react-statics": "^3.0.1",
+        "react-native-gesture-handler": "~1.0.14",
+        "react-native-safe-area-view": "^0.12.0",
+        "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
+      }
+    },
+    "@react-navigation/core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-vVPUIpCWO3VKVvE5zYDDR/lOy5hHvRm60rQAHTF19vmt3Jqnbs3qqgYovfUAnTBm0crGLcuIwzOuprRIhC4bfQ==",
+      "requires": {
+        "create-react-context": "0.2.2",
+        "hoist-non-react-statics": "^3.0.1",
+        "path-to-regexp": "^1.7.0",
+        "query-string": "^6.2.0",
+        "react-is": "^16.5.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "@react-navigation/native": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-3.1.4.tgz",
+      "integrity": "sha512-Py9+FDgwT1AvQE+NzVtvcaGF5IxLtFu7XxEaDvcnI8LFeOt/CVESdJJW8kgxJuYhQQzgLZagQ2hwz5kU2I7tYg==",
+      "requires": {
+        "hoist-non-react-statics": "^3.0.1",
+        "react-native-gesture-handler": "~1.0.14",
+        "react-native-safe-area-view": "^0.12.0",
+        "react-native-screens": "^1.0.0 || ^1.0.0-alpha"
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -2269,6 +2317,31 @@
         "fbjs": "^0.8.9",
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
+      }
+    },
+    "create-react-context": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
+      "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
+      "requires": {
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
       },
       "dependencies": {
         "fbjs": {
@@ -3710,6 +3783,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "handlebars": {
       "version": "4.0.12",
@@ -7869,6 +7947,21 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
+    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -8064,6 +8157,15 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "query-string": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.2.0.tgz",
+      "integrity": "sha512-5wupExkIt8RYL4h/FE+WTg3JHk62e6fFPWtAZA9J5IWK1PfTfKkMS93HBUHcFpeYi9KsY5pFbh+ldvEyaz5MyA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
@@ -8205,6 +8307,120 @@
         "xcode": "^1.0.0",
         "xmldoc": "^0.4.0",
         "yargs": "^9.0.0"
+      }
+    },
+    "react-native-gesture-handler": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.0.15.tgz",
+      "integrity": "sha512-BePn+YOKcspHb1xPkUdJs+H6jiaECrT2c98txADBYWHwuUeundE+uUJG0r3FQLFvM2MoGeiJeD96sePzk+WSvQ==",
+      "requires": {
+        "hoist-non-react-statics": "^2.3.1",
+        "invariant": "^2.2.2",
+        "prop-types": "^15.5.10"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
+    "react-native-module-check": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-native-module-check/-/react-native-module-check-2.6.2.tgz",
+      "integrity": "sha512-Thm+dfELhc7FZ86Hsoxc25gtQa65C+Z9BXhi9rxDcnRKwCJ+DoCED5jdfvFm8g03WzYkqGojncZ1lNZ+c/sfUg==",
+      "requires": {
+        "invariant": "^2.2.2",
+        "warning": "^3.0.0"
+      }
+    },
+    "react-native-module-guard": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-native-module-guard/-/react-native-module-guard-2.6.2.tgz",
+      "integrity": "sha512-jXY25yZVYf2VpYU/vC7lsZ4b/9avP7otrZVQ/OQRf39KasxRYaIZTmR69LYlguM7x9Vo3VXe27zor9fibwfi1A==",
+      "requires": {
+        "warning": "^3.0.0"
+      }
+    },
+    "react-native-package": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-native-package/-/react-native-package-2.6.2.tgz",
+      "integrity": "sha512-Ic8jFJI/CBgxAOGA/iCPkM8nFj6tMstGUIiUIWP4JlBlod0EtVQ+ch8y61XFdfBM7AhUdYQ77HplJ7GgtF1JxQ==",
+      "requires": {
+        "react-native-module-check": "^2.6.2",
+        "react-native-module-guard": "^2.6.2"
+      }
+    },
+    "react-native-safe-area-view": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-view/-/react-native-safe-area-view-0.12.0.tgz",
+      "integrity": "sha512-UrAXmBC4KNR5K2eczIDZgqceWyKsgG9gmWFerHCvoyApfei8ceBB9u/c//PWCpS5Gt8MRLTmX5jPtzdXo2yNqg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.3.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
+      }
+    },
+    "react-native-screens": {
+      "version": "1.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-1.0.0-alpha.22.tgz",
+      "integrity": "sha512-kSyAt0AeVU6N7ZonfV6dP6iZF8B7Bce+tk3eujXhzBGsLg0VSLnU7uE9VqJF0xdQrHR91ZjGgVMieo/8df9KTA=="
+    },
+    "react-native-tab-view": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-1.3.2.tgz",
+      "integrity": "sha512-2U+HxDQdjzExoC6gZ+wUhC8v8JjntppsFVU4v4pRvC/1dkN7DJv1k8UEy9+p7ucEaNrcAzu/j5N09Jf4qG36vw==",
+      "requires": {
+        "prop-types": "^15.6.1"
+      }
+    },
+    "react-navigation": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/react-navigation/-/react-navigation-3.2.1.tgz",
+      "integrity": "sha512-l0vm1orpEAeMdPxTLbe0xxqUDtCVAcgT8q0+xwGnmRT1+2QhRYXSAjQ1md3RJaeg1wCnlfxtMbLUnkf5z4cDkw==",
+      "requires": {
+        "@react-navigation/core": "3.1.1",
+        "@react-navigation/native": "3.1.4",
+        "react-navigation-drawer": "1.1.0",
+        "react-navigation-stack": "1.0.9",
+        "react-navigation-tabs": "1.0.2"
+      }
+    },
+    "react-navigation-drawer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/react-navigation-drawer/-/react-navigation-drawer-1.1.0.tgz",
+      "integrity": "sha512-OtO8g+t0pufbL0aiyZ9y2+j7cWIu9+agiaJfOiE2vPDOqGimpVfEYEuWj0xodKVRrEC4xrb8flqoxMxpE0wjdg==",
+      "requires": {
+        "react-native-tab-view": "^1.2.0"
+      }
+    },
+    "react-navigation-stack": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/react-navigation-stack/-/react-navigation-stack-1.0.9.tgz",
+      "integrity": "sha512-N1h0Kkz8WmSHbBbPHEpVh+ss/1NwWoWk6v2L68kxbpTcEH986t5mz0abp4KHY8pb0nHGbY0jkn5IYiOJBfN0tQ=="
+    },
+    "react-navigation-tabs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/react-navigation-tabs/-/react-navigation-tabs-1.0.2.tgz",
+      "integrity": "sha512-ffWPVdo+L0GLbQlLAzH7ITYqh9V9NdqT/juj8QtESH5/2yUqfvqTxQoSowvFIrtiIHHFH6tLoQy1sZZciTxmeg==",
+      "requires": {
+        "hoist-non-react-statics": "^2.5.0",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-native-tab-view": "^1.0.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+        }
       }
     },
     "react-proxy": {
@@ -9355,6 +9571,11 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
       "integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -11,6 +11,7 @@
     "@heap/react-native-heap": "heap-react-native-heap-0.1.2.tgz",
     "react": "16.6.1",
     "react-native": "0.57.5",
+    "react-navigation": "^3.2.1",
     "react-redux": "^5.1.1",
     "redux": "^4.0.1"
   },

--- a/examples/TestDriver/src/mainScreen.js
+++ b/examples/TestDriver/src/mainScreen.js
@@ -33,6 +33,7 @@ class MainScreen extends Component {
         <Button testID="aep" title="Add Event Properties" onPress={() => Heap.addEventProperties({eventProp1: 'bar', eventProp2: 'foo'})}></Button>
         <Button testID="removeProp" title="Remove eventProp1" onPress={() => Heap.removeEventProperty('eventProp1')}></Button>
         <Button testID="clearProps" title="Clear Event Properties" onPress={() => Heap.clearEventProperties()}></Button>
+        <Button title="Navigate" onPress={() => this.props.navigation.navigate('Other')}/>
         <TouchableOpacity testID="touchableOpacityText">
           <Text>Touchable Opacity</Text>
           <Text>Foo</Text>

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -36,12 +36,10 @@ const NavigationService = {
 const withHeapNavigationAutotrack = (AppContainer) => {
   return class extends React.Component {
     componentDidMount() {
-      console.log(navRef);
       const initialPageviewPath = getActiveRouteName(navRef.state.nav);
       track('screenview', {
         path: initialPageviewPath,
       });
-      console.log(initialPageviewPath);
     }
 
     render() {
@@ -51,11 +49,13 @@ const withHeapNavigationAutotrack = (AppContainer) => {
             NavigationService.setTopLevelNavigator(navigatorRef);
           }}
           onNavigationStateChange={(prev, next, action) => {
-            if (action.type === 'Navigation/NAVIGATE' || action.type === 'Navigation/BACK') {
+            const prevScreenRoute = getActiveRouteName(prev);
+            const nextScreenRoute = getActiveRouteName(next);
+            if (prevScreenRoute !== nextScreenRoute) {
               const currentScreen = getActiveRouteName(next);
-              console.log('New Pageview', currentScreen);
               track('screenview', {
                 path: currentScreen,
+                type: action.type,
               });
             }
           }}

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -26,17 +26,12 @@ getActiveRouteName = (navigationState) => {
   return route.routeName;
 }
 
-let navRef = null;
-const NavigationService = {
-  setTopLevelNavigator: (ref) => {
-    navRef = ref;
-  }
-}
-
-const withHeapNavigationAutotrack = (AppContainer) => {
+const withReactNavigationAutotrack = (AppContainer) => {
   return class extends React.Component {
+    topLevelNavigator = null;
+
     componentDidMount() {
-      const initialPageviewPath = getActiveRouteName(navRef.state.nav);
+      const initialPageviewPath = getActiveRouteName(topLevelNavigator.state.nav);
       track('screenview', {
         path: initialPageviewPath,
       });
@@ -46,7 +41,7 @@ const withHeapNavigationAutotrack = (AppContainer) => {
       return (
         <AppContainer
           ref={navigatorRef => {
-            NavigationService.setTopLevelNavigator(navigatorRef);
+            topLevelNavigator = navigatorRef;
           }}
           onNavigationStateChange={(prev, next, action) => {
             const prevScreenRoute = getActiveRouteName(prev);
@@ -113,7 +108,7 @@ export default {
     track(eventType, autotrackProps);
   },
 
-  withHeapNavigationAutotrack,
+  withReactNavigationAutotrack,
 };
 
 // :TODO: (jmtaber129): Consider implementing sibling target text.


### PR DESCRIPTION
This includes a POC for autotrack of screenviews for apps using `react-navigation`.  It uses the `onNavigationStateChange` of `react-navigation`'s `NavigationContainer` (created by `createAppContainer`) to listen for navigation events that look like screenview transitions, and then determine the path in the navigation router, of the format `<top route name>::<route name>::<route name>::<etc.>`.  For example, when a navigation event leads to a screenview on the `MainScreen` in the `StackNav` navigator within the `AppNavigator` within the `TopNavigator`, the path would be `Main::Main::Original`, since `Main` is the name of the `AppNavigator` route, `Main` is the name of the `StackNav` route, and `Original` is the name of the `MainScreen` route.

This listener is added by creating a HOC of the app's `NavigationContainer` using a method currently named `withHeapNavigationAutotrack()` (note that this doesn't currently correctly pass through props/etc. like a HOC wrapper should).

The two relevant files are `examples/TestDriver/App.js` (where routing + additional screens were added) and `js/Heap.js` (where the HOC wrapper function + tracking utils were added).