### PR TITLE
Move detox tests from internal repo

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,2 @@
+# React Native Tests
+This folder contains automated tests against the TestDriver app in the `examples/` folder. The test assertions depend on internal Heap utilities, so the tests can only be run by Heap engineers with access to the internal repo. Further instructions can be found in the internal repo [here](https://github.com/heap/heap/blob/develop/test/tracker/react-native/README.md).

--- a/e2e/firstTest.spec.js
+++ b/e2e/firstTest.spec.js
@@ -1,0 +1,240 @@
+require('coffeescript').register();
+_ = require('lodash');
+assert = require('should/as-function')
+
+db = require('../../heap/back/db');
+testUtil = require('../../heap/test/util');
+
+const assertEvent = (err, res, check) => {
+  assert.not.exist(err);
+  assert(res.length).not.equal(0);
+
+  if (_.isFunction(check)) {
+    assert(res.filter(check).length).not.equal(0);
+  };
+};
+
+const assertIosPixel = async (event, check) => {
+  const { err, res } = await new Promise((resolve, reject) => {
+    testUtil.findEventInRedisRequests(event, (err, res) => {
+      resolve({ err, res });
+    });
+  });
+
+  assertEvent(err, res, check);
+};
+
+const assertAndroidEvent = async (event, check) => {
+  const { err, res } = await new Promise((resolve, reject) => {
+    testUtil.findAndroidEventInRedisRequests(event, (err, res) => {
+      resolve({ err ,res });
+    });
+  });
+
+  assertEvent(err, res, check);
+};
+
+const assertAndroidAutotrackHierarchy = async (expectedName, expectedHierarchy, expectedTargetText) => {
+  return assertAndroidEvent({
+    envId: "2084764307",
+    event: {
+      custom: {
+        name: expectedName,
+        properties: {
+          touchableHierarchy: {
+            string: expectedHierarchy,
+          },
+          targetText: {
+            string: expectedTargetText,
+          },
+        },
+      },
+    },
+  });
+};
+
+assertAutotrackHierarchy = async (expectedName, expectedHierarchy, expectedTargetText) => {
+  if (device.getPlatform() === 'android') {
+    return assertAndroidAutotrackHierarchy(expectedName, expectedHierarchy, expectedTargetText);
+  } else if (device.getPlatform() === 'ios') {
+    return assertIosPixel({ t: expectedName, k: [ 'touchableHierarchy', expectedHierarchy, 'targetText', expectedTargetText ]});
+  } else {
+    throw new Error(`Unknown device type: ${device.getPlatform()}`)
+  }
+}
+
+const doTestActions = async () => {
+  await expect(element(by.id('track1'))).toBeVisible();
+  await element(by.id('track1')).tap();
+  await element(by.id('aep')).tap();
+  await element(by.id('track2')).tap();
+  await element(by.id('removeProp')).tap();
+  await element(by.id('track3')).tap();
+  await element(by.id('clearProps')).tap();
+  await element(by.id('track4')).tap();
+  await element(by.id('aup')).tap();
+  await element(by.id('identify')).tap();
+  await element(by.id('touchableOpacityText')).tap();
+  await element(by.id('touchableHighlightText')).tap();
+  await element(by.id('touchableWithoutFeedbackText')).tap();
+
+  if (device.getPlatform() === 'android') {
+    await element(by.id('touchableNativeFeedbackText')).tap();
+  }
+};
+
+describe('ReactNative Support', () => {
+  before(async () => {
+    await device.launchApp();
+  });
+
+  before((done) => {
+    db.orm.connection.sharedRedis().flushall(done)
+  });
+
+  describe(':ios: Bridge API', () => {
+    before(async () => {
+      await doTestActions()
+      // Heap iOS flushes events every 15 seconds. Wait 16 seconds to ensure that
+      // all events are flushed to redis before asserting.
+      // :TODO:(jmtaber129): Make this wait shorter if/when we expose setting the
+      // flush frequency to the RN bridge.
+      await new Promise(resolve => setTimeout(resolve, 16000));
+    });
+
+    it('should call first track', async () => {
+      await assertIosPixel({ a: "2084764307", t: 'pressInTestEvent1' }, (event) => {
+        return !(_.includes(event.k, 'eventProp1') || _.includes(event.k, 'eventProp2'));
+      });
+    });
+
+    it('should add event properties', async () => {
+      await assertIosPixel({ a: "2084764307", t: 'pressInTestEvent2' }, (event) => {
+        return (_.includes(event.k, 'eventProp1') && _.includes(event.k, 'eventProp2'));
+      });
+    });
+
+    it('should remove event properties', async () => {
+      await assertIosPixel({ a: "2084764307", t: 'pressInTestEvent3' }, (event) => {
+        return (!_.includes(event.k, 'eventProp1') && _.includes(event.k, 'eventProp2'));
+      });
+    });
+
+    it('should clear event properties', async () => {
+      await assertIosPixel({ a: "2084764307", t: 'pressInTestEvent4' }, (event) => {
+        return !(_.includes(event.k, 'eventProp1') || _.includes(event.k, 'eventProp2'));
+      });
+    });
+
+    it('should add user properties', async () => {
+      const { err, res } = await new Promise(resolve => {
+        testUtil.findAddUserPropertiesRequestsInRedis((err, res) => {
+          resolve({ err, res });
+        });
+      });
+
+      assert.not.exist(err);
+      assert(res.length).equal(1);
+      assert(res[0]['_prop1']).equal('foo');
+      assert(res[0]['_prop2']).equal('bar');
+    });
+
+    it('should send identify', async () => {
+      const { err, res } = await new Promise(resolve => {
+        testUtil.findIdentifyRequestsInRedis((err, res) => {
+          resolve({ err, res });
+        });
+      });
+
+      assert.not.exist(err);
+      assert(res.length).equal(1);
+      assert(res[0]['i']).equal('foobar');
+    });
+  });
+
+  describe(':android: Bridge API', () => {
+    before(async () => {
+      await doTestActions();
+      // Heap Android flushes events every 15 seconds. Wait 16 seconds to ensure that
+      // all events are flushed to redis before asserting.
+      // :TODO:(jmtaber129): Make this wait shorter if/when we expose setting the
+      // flush frequency to the RN bridge.
+      await new Promise(resolve => setTimeout(resolve, 16000));
+    });
+
+    it('should call first track', async () => {
+      await assertAndroidEvent({ envId: "2084764307", event: { custom: { name: 'pressInTestEvent1' }}}, (event) => {
+        return (!_.has(event.properties, 'eventProp1') && !_.has(event.properties, 'eventProp2'));
+      });
+    });
+
+    it('should add event properties', async () => {
+      await assertAndroidEvent({ envId: "2084764307", event: { custom: { name: 'pressInTestEvent2' }}}, (event) => {
+        return (_.has(event.properties, 'eventProp1') && _.has(event.properties, 'eventProp2'));
+      });
+    });
+
+    it('should remove event properties', async () => {
+      await assertAndroidEvent({ envId: "2084764307", event: { custom: { name: 'pressInTestEvent3' }}}, (event) => {
+        return (!_.has(event.properties, 'eventProp1') && _.has(event.properties, 'eventProp2'));
+      });
+    });
+
+    it('should clear event properties', async () => {
+      await assertAndroidEvent({ envId: "2084764307", event: { custom: { name: 'pressInTestEvent4' }}}, (event) => {
+        return (!_.has(event.properties, 'eventProp1') && !_.has(event.properties, 'eventProp2'));
+      });
+    });
+
+    it('should add user properties', async () => {
+      const { err, res } = await new Promise(resolve => {
+        testUtil.findAndroidAupInRedisRequests((err, res) => {
+          resolve({ err, res });
+        });
+      });
+
+      assert.not.exist(err);
+      // Android might send an AUP with initial props when the app first opens.
+      assert(res.length).not.equal(0);
+      assert(res[0]['properties']).deepEqual({"prop2":{"string":"bar"},"prop1":{"string":"foo"}});
+    });
+
+    it('should send identify', async () => {
+      const { err, res } = await new Promise(resolve => {
+        testUtil.findAndroidIdentifyInRedisRequests((err, res) => {
+          resolve({ err, res });
+        });
+      });
+
+      assert.not.exist(err);
+      assert(res.length).equal(1);
+      assert(res[0]['toIdentity']).equal('foobar');
+    });
+  });
+
+  describe('Autotrack', () => {
+    it("should autotrack 'TouchableOpacity's", async () => {
+      const expectedHierarchy = 'AppContainer;|App;|Provider;|Connect(MainScreen);|MainScreen;|TouchableOpacity;|';
+      const expectedTargetText = 'Touchable Opacity Foo';
+      await assertAutotrackHierarchy('touchableHandlePress', expectedHierarchy, expectedTargetText);
+    });
+
+    it("should autotrack 'TouchableHighlight's", async () => {
+      const expectedHierarchy = 'AppContainer;|App;|Provider;|Connect(MainScreen);|MainScreen;|TouchableHighlight;|';
+      const expectedTargetText = 'Touchable Highlight';
+      await assertAutotrackHierarchy('touchableHandlePress', expectedHierarchy, expectedTargetText);
+    });
+
+    it("should autotrack 'TouchableWithoutFeedback's", async () => {
+      const expectedHierarchy = 'AppContainer;|App;|Provider;|Connect(MainScreen);|MainScreen;|TouchableWithoutFeedback;|';
+      const expectedTargetText = 'Touchable Without Feedback';
+      await assertAutotrackHierarchy('touchableHandlePress', expectedHierarchy, expectedTargetText);
+    });
+
+    it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
+      const expectedHierarchy = 'AppContainer;|App;|Provider;|Connect(MainScreen);|MainScreen;|TouchableNativeFeedback;|';
+      const expectedTargetText = 'Touchable Native Feedback';
+      await assertAutotrackHierarchy('touchableHandlePress', expectedHierarchy, expectedTargetText);
+    });
+  });
+});

--- a/e2e/init.js
+++ b/e2e/init.js
@@ -1,0 +1,19 @@
+const detox = require('detox');
+const config = require('../../heap/package.json').detox;
+const adapter = require('detox/runners/mocha/adapter');
+
+before(async () => {
+  await detox.init(config);
+});
+
+beforeEach(async function () {
+  await adapter.beforeEach(this);
+});
+
+afterEach(async function () {
+  await adapter.afterEach(this);
+});
+
+after(async () => {
+  await detox.cleanup();
+});

--- a/e2e/mocha.opts
+++ b/e2e/mocha.opts
@@ -1,0 +1,1 @@
+--recursive --timeout 120000

--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,6 +2064,12 @@
       "dev": true,
       "optional": true
     },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "dev": true
+    },
     "bplist-creator": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
@@ -2173,6 +2179,28 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "bunyan": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "dev": true,
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
+    },
+    "bunyan-debug-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bunyan-debug-stream/-/bunyan-debug-stream-1.1.1.tgz",
+      "integrity": "sha512-jJbQ1gXUL6vMmZVdbaTFK1v1sGa7axLrSQQwkB6HU9HCPTzsw2HsKcPHm1vgXZlEck/4IvEuRwg/9+083YelCg==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.0.3",
+        "exception-formatter": "^1.0.4"
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -2273,6 +2301,29 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "child-process-promise": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
+      "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^4.0.2",
+        "node-version": "^1.0.0",
+        "promise-polyfill": "^6.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "chokidar": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
@@ -2317,15 +2368,13 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "arr-flatten": "^1.1.0",
             "array-unique": "^0.3.2",
@@ -2344,7 +2393,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -2519,7 +2567,6 @@
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-number": "^3.0.0",
@@ -2532,7 +2579,6 @@
               "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-extendable": "^0.1.0"
               }
@@ -2598,8 +2644,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.0",
@@ -2616,7 +2661,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -2626,7 +2670,6 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -2637,15 +2680,13 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -2750,6 +2791,12 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "coffeescript": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
+      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
+      "dev": true
+    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -2777,6 +2824,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
     },
     "combined-stream": {
@@ -3147,6 +3200,58 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
+    "detox": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/detox/-/detox-10.0.7.tgz",
+      "integrity": "sha512-oHunX6M+5qy01Sy+o0MGInOkFpROKFfDXU7Z9aUywlXSjNxCUHFUc4J/mgJdFYTogA2W3Md+Mt4kc89+nwqztQ==",
+      "dev": true,
+      "requires": {
+        "bunyan": "^1.8.12",
+        "bunyan-debug-stream": "^1.1.0",
+        "child-process-promise": "^2.2.0",
+        "commander": "^2.15.1",
+        "fs-extra": "^4.0.2",
+        "get-port": "^2.1.0",
+        "ini": "^1.3.4",
+        "lodash": "^4.17.5",
+        "minimist": "^1.2.0",
+        "proper-lockfile": "^3.0.2",
+        "sanitize-filename": "^1.6.1",
+        "shell-utils": "^1.0.9",
+        "tail": "^1.2.3",
+        "telnet-client": "0.15.3",
+        "tempfile": "^2.0.0",
+        "ws": "^1.1.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -3172,6 +3277,16 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "dtrace-provider": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.10.0"
       }
     },
     "ecc-jsbn": {
@@ -3343,6 +3458,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
       "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
       "dev": true
+    },
+    "exception-formatter": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exception-formatter/-/exception-formatter-1.0.7.tgz",
+      "integrity": "sha512-zV45vEsjytJrwfGq6X9qd1Ll56cW4NC2mhCO6lqwMk4ZpA1fZ6C3UiaQM/X7if+7wZFmCgss3ahp9B/uVFuLRw==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.0.3"
+      }
     },
     "exec-sh": {
       "version": "0.2.2",
@@ -3722,8 +3846,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3744,14 +3867,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3766,20 +3887,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3896,8 +4014,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3909,7 +4026,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3924,7 +4040,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3932,14 +4047,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3958,7 +4071,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4039,8 +4151,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4052,7 +4163,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4138,8 +4248,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4175,7 +4284,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4195,7 +4303,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4239,14 +4346,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4274,6 +4379,15 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
+    },
+    "get-port": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-2.1.0.tgz",
+      "integrity": "sha1-h4P53OvR7qSVozThpqJR54iHqxo=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "get-stream": {
       "version": "3.0.0",
@@ -4654,6 +4768,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
@@ -9288,6 +9408,13 @@
         }
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "dev": true,
+      "optional": true
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
@@ -9311,6 +9438,44 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "mv": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.4.5",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
+        }
+      }
     },
     "nan": {
       "version": "2.12.1",
@@ -9383,6 +9548,13 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "ncp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "dev": true,
+      "optional": true
+    },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -9433,6 +9605,12 @@
       "requires": {
         "semver": "^5.3.0"
       }
+    },
+    "node-version": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
+      "integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -9927,6 +10105,21 @@
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
     "pirates": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.0.tgz",
@@ -10059,6 +10252,12 @@
         "asap": "~2.0.3"
       }
     },
+    "promise-polyfill": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
+      "integrity": "sha1-36lpQ+qcEh/KTem1hoyznTRy4Fc=",
+      "dev": true
+    },
     "prompts": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.1.tgz",
@@ -10077,6 +10276,17 @@
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
+      }
+    },
+    "proper-lockfile": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-3.2.0.tgz",
+      "integrity": "sha512-iMghHHXv2bsxl6NchhEaFck8tvX3F9cknEEh1SUpguUOBjN7PAAW9BLzmbc1g/mCD1gY3EE2EABBHPJfFdHFmA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "pseudomap": {
@@ -10527,8 +10737,7 @@
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "braces": {
           "version": "2.3.2",
@@ -10814,8 +11023,7 @@
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "micromatch": {
           "version": "3.1.10",
@@ -11097,6 +11305,12 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -11140,6 +11354,13 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "dev": true,
+      "optional": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -11514,6 +11735,15 @@
         }
       }
     },
+    "sanitize-filename": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
+      "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
+      "dev": true,
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -11654,6 +11884,15 @@
         "array-map": "~0.0.0",
         "array-reduce": "~0.0.0",
         "jsonify": "~0.0.0"
+      }
+    },
+    "shell-utils": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/shell-utils/-/shell-utils-1.0.10.tgz",
+      "integrity": "sha512-p1xuqhj3jgcXiV8wGoF1eL/NOvapN9tyGDoObqKwvZTUZn7fIzK75swLTEHfGa7sObeN9vxFplHw/zgYUYRTsg==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.x.x"
       }
     },
     "shellwords": {
@@ -12140,6 +12379,21 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
+    "tail": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tail/-/tail-1.4.0.tgz",
+      "integrity": "sha512-wjwfZw6wcMFTB1Po7NFUf4TdCDwX8duZjdTMhnHBEC677Q6mFRcVZE7f/nZDhG2Fpf/wEEKOJP9L7/b11/vlHQ==",
+      "dev": true
+    },
+    "telnet-client": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/telnet-client/-/telnet-client-0.15.3.tgz",
+      "integrity": "sha512-GSfdzQV0BKIYsmeXq7bJFJ2wHeJud6icaIxCUf6QCGQUD6R0BBGbT1+yLDhq67JRdgRpwyPwUbV7JxFeRrZomQ==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.x"
+      }
+    },
     "temp": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
@@ -12156,6 +12410,22 @@
           "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
+      }
+    },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "dev": true
+    },
+    "tempfile": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
+      "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
+      "dev": true,
+      "requires": {
+        "temp-dir": "^1.0.0",
+        "uuid": "^3.0.1"
       }
     },
     "test-exclude": {
@@ -12304,6 +12574,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "dev": true,
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
     },
     "ts-jest": {
       "version": "23.10.5",
@@ -12496,6 +12775,12 @@
         }
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -12574,6 +12859,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=",
       "dev": true
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   },
   "dependencies": {
     "@babel/core": "^7.2.2",
+    "babel-plugin-add-react-displayname": "0.0.5",
     "babel-template": "^6.26.0",
     "babel-types": "^6.26.0",
     "flat": "^4.1.0",
     "lodash.pick": "^4.4.0",
-    "babel-plugin-add-react-displayname": "0.0.5",
     "typescript-collections": "^1.3.2"
   },
   "peerDependencies": {
@@ -44,7 +44,9 @@
     "@types/jest": "^23.3.13",
     "@types/lodash": "^4.14.120",
     "@types/node": "^10.12.19",
+    "coffeescript": "^1.12.7",
     "deep-freeze": "0.0.1",
+    "detox": "^10.0.7",
     "jest": "^24.0.0",
     "lodash": "^4.17.11",
     "mocha": "^5.2.0",


### PR DESCRIPTION
To make it easier to keep e2e tests in-sync with the library, we're moving the detox tests from the internal repo to the public repo.

Because the test assertions depend on internal utils, the tests can only be run by those with access to the internal repo (i.e. Heap engineers).

Additional details are in the corresponding PR in the internal repo.