### PR TITLE
Use memoizedProps when stateNode is null

### DIFF
--- a/js/Heap.js
+++ b/js/Heap.js
@@ -118,7 +118,7 @@ const getFiberNodeComponentHierarchy = currNode => {
 
   const propsString = extractProps(
     elementName,
-    currNode.stateNode,
+    currNode,
     builtinPropExtractorConfig
   );
 

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -3,11 +3,13 @@ import { getCombinedInclusionList } from './combineConfigs';
 const pick = require('lodash.pick');
 const flatten = require('flat');
 
-export interface Component {
-  props: {
+export interface FiberNode {
+  memoizedProps: {
     [propertyKey: string]: any;
   };
-  heapOptions?: ClassHeapOptions;
+  stateNode?: {
+    heapOptions?: ClassHeapOptions;
+  };
 }
 
 export interface ClassHeapOptions {
@@ -27,16 +29,16 @@ const EMPTY_CRITERIA = { include: [] };
 
 export const extractProps = (
   elementName: string,
-  component: Component,
+  fiberNode: FiberNode,
   config: PropExtractorConfig
 ): string => {
-  if (!component) {
+  if (!fiberNode) {
     return '';
   }
 
   let classCriteria: PropExtractorCriteria = EMPTY_CRITERIA;
-  if (component.heapOptions && component.heapOptions.eventProps) {
-    classCriteria = component.heapOptions.eventProps as PropExtractorCriteria;
+  if (fiberNode.stateNode && fiberNode.stateNode.heapOptions && fiberNode.stateNode.heapOptions.eventProps) {
+    classCriteria = fiberNode.stateNode.heapOptions.eventProps as PropExtractorCriteria;
   }
 
   const builtInCriteria = config[elementName] || EMPTY_CRITERIA;
@@ -46,7 +48,15 @@ export const extractProps = (
     classCriteria,
   ]);
 
-  const filteredProps = pick(component.props, inclusionList);
+  // :TODO: (jmtaber129): Determine if we should just always get props from 'memoizedProps'.
+  let props;
+  if (fiberNode.stateNode) {
+    props = fiberNode.stateNode.props;
+  } else {
+    props = fiberNode.memoizedProps;
+  }
+
+  const filteredProps = pick(props, inclusionList);
   const flattenedProps = flatten(filteredProps);
   let propsString = '';
 

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -3,13 +3,18 @@ import { getCombinedInclusionList } from './combineConfigs';
 const pick = require('lodash.pick');
 const flatten = require('flat');
 
-export interface FiberNode {
-  memoizedProps: {
+export interface StateNode {
+  props?: {
     [propertyKey: string]: any;
   };
-  stateNode?: {
-    heapOptions?: ClassHeapOptions;
+  heapOptions?: ClassHeapOptions;
+}
+
+export interface FiberNode {
+  memoizedProps?: {
+    [propertyKey: string]: any;
   };
+  stateNode?: StateNode;
 }
 
 export interface ClassHeapOptions {


### PR DESCRIPTION
For functional components, the fiber node has no `stateNode`, so we should get included props from `memoizedProps` instead.