### PR TITLE
Allow prop capture configs to be attached to functional components

### DIFF
--- a/examples/TestDriver/package-lock.json
+++ b/examples/TestDriver/package-lock.json
@@ -856,7 +856,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:heap-react-native-heap-0.2.0-alpha1.tgz",
-      "integrity": "sha512-OPdCWdQqD2sx6wuQOGkc6Yzi2n/MP/Bk0NtY9UaDDJFK/PgCwilRwtrgm2zKn7nxrlf8wKbCzgQU5Nw0jFHBAw==",
+      "integrity": "sha512-v1XKo2i6aMo8/oRwyG+sL7FpZwqPiBtUL4GnMDyaYOkdLdePC8jz0CCPurv1Z8byj9ApiL5dbd3mVIf8RK+aug==",
       "requires": {
         "@babel/core": "^7.2.2",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/js/util/__tests__/extractProps.spec.ts
+++ b/js/util/__tests__/extractProps.spec.ts
@@ -53,7 +53,7 @@ describe('Extracting Props with a configuration', () => {
   });
 
   test('can handle if a prop is null or undefined', () => {
-    const obj2 = _.merge({}, obj1, { stateNode: {props: { c: null } }});
+    const obj2 = _.merge({}, obj1, { stateNode: { props: { c: null } } });
     expect(extractProps('Element', obj2, config)).toEqual('[a=foo];');
 
     const config2 = _.merge({}, config, { Obj1: { include: ['a', 'c', 'd'] } });
@@ -141,7 +141,9 @@ describe('Extracting Props with a configuration', () => {
       memoizedProps: obj1.stateNode.props,
     };
 
-    expect(extractProps('Element', objNoStateNode, config)).toEqual('[a=foo];[c=true];');
+    expect(extractProps('Element', objNoStateNode, config)).toEqual(
+      '[a=foo];[c=true];'
+    );
   });
 
   test('uses type.heapOptions when there is no stateNode', () => {
@@ -152,7 +154,9 @@ describe('Extracting Props with a configuration', () => {
       },
     };
 
-    expect(extractProps('Element', objNoStateNodePropConfig, config)).toEqual('[a=foo];[b=7];[c=true];');
+    expect(extractProps('Element', objNoStateNodePropConfig, config)).toEqual(
+      '[a=foo];[b=7];[c=true];'
+    );
   });
 
   test('uses stateNode.heapOptions and not type.heapOptions if stateNode exists', () => {
@@ -166,6 +170,8 @@ describe('Extracting Props with a configuration', () => {
       },
     };
 
-    expect(extractProps('Element', objMultipleHeapOptions, config)).toEqual('[a=foo];[c=true];');
+    expect(extractProps('Element', objMultipleHeapOptions, config)).toEqual(
+      '[a=foo];[c=true];'
+    );
   });
 });

--- a/js/util/__tests__/extractProps.spec.ts
+++ b/js/util/__tests__/extractProps.spec.ts
@@ -143,4 +143,29 @@ describe('Extracting Props with a configuration', () => {
 
     expect(extractProps('Element', objNoStateNode, config)).toEqual('[a=foo];[c=true];');
   });
+
+  test('uses type.heapOptions when there is no stateNode', () => {
+    const objNoStateNodePropConfig = {
+      memoizedProps: obj1.stateNode.props,
+      type: {
+        heapOptions: objWithEventProps.stateNode.heapOptions,
+      },
+    };
+
+    expect(extractProps('Element', objNoStateNodePropConfig, config)).toEqual('[a=foo];[b=7];[c=true];');
+  });
+
+  test('uses stateNode.heapOptions and not type.heapOptions if stateNode exists', () => {
+    const objMultipleHeapOptions = {
+      stateNode: {
+        props: obj1.stateNode.props,
+      },
+      type: {
+        // This should be ignored, since the 'stateNode' exists.
+        heapOptions: objWithEventProps.stateNode.heapOptions,
+      },
+    };
+
+    expect(extractProps('Element', objMultipleHeapOptions, config)).toEqual('[a=foo];[c=true];');
+  });
 });

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -17,7 +17,7 @@ export interface FiberNode {
   stateNode?: StateNode;
   type?: {
     heapOptions?: ClassHeapOptions;
-  }
+  };
 }
 
 export interface ClassHeapOptions {
@@ -45,10 +45,21 @@ export const extractProps = (
   }
 
   let classCriteria: PropExtractorCriteria = EMPTY_CRITERIA;
-  if (fiberNode.stateNode && fiberNode.stateNode.heapOptions && fiberNode.stateNode.heapOptions.eventProps) {
-    classCriteria = fiberNode.stateNode.heapOptions.eventProps as PropExtractorCriteria;
-  } else if (!fiberNode.stateNode && fiberNode.type && fiberNode.type.heapOptions && fiberNode.type.heapOptions.eventProps) {
-    classCriteria = fiberNode.type.heapOptions.eventProps as PropExtractorCriteria;
+  if (
+    fiberNode.stateNode &&
+    fiberNode.stateNode.heapOptions &&
+    fiberNode.stateNode.heapOptions.eventProps
+  ) {
+    classCriteria = fiberNode.stateNode.heapOptions
+      .eventProps as PropExtractorCriteria;
+  } else if (
+    !fiberNode.stateNode &&
+    fiberNode.type &&
+    fiberNode.type.heapOptions &&
+    fiberNode.type.heapOptions.eventProps
+  ) {
+    classCriteria = fiberNode.type.heapOptions
+      .eventProps as PropExtractorCriteria;
   }
 
   const builtInCriteria = config[elementName] || EMPTY_CRITERIA;

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -15,6 +15,9 @@ export interface FiberNode {
     [propertyKey: string]: any;
   };
   stateNode?: StateNode;
+  type?: {
+    heapOptions?: ClassHeapOptions;
+  }
 }
 
 export interface ClassHeapOptions {
@@ -44,6 +47,8 @@ export const extractProps = (
   let classCriteria: PropExtractorCriteria = EMPTY_CRITERIA;
   if (fiberNode.stateNode && fiberNode.stateNode.heapOptions && fiberNode.stateNode.heapOptions.eventProps) {
     classCriteria = fiberNode.stateNode.heapOptions.eventProps as PropExtractorCriteria;
+  } else if (!fiberNode.stateNode && fiberNode.type && fiberNode.type.heapOptions && fiberNode.type.heapOptions.eventProps) {
+    classCriteria = fiberNode.type.heapOptions.eventProps as PropExtractorCriteria;
   }
 
   const builtInCriteria = config[elementName] || EMPTY_CRITERIA;

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -45,6 +45,13 @@ export const extractProps = (
   }
 
   let classCriteria: PropExtractorCriteria = EMPTY_CRITERIA;
+
+  // For React class components, 'fiberNode' has a 'stateNode' prop that corresponds to the 'this'
+  // context of the class instance, so if 'heapOptions' exists, they will be on 'stateNode'. For
+  // functional components, there is no 'stateNode', and 'heapOptions' are assigned as a prop to
+  // 'type', so if 'heapOptions' exists, they will be on 'type', instead. We should look for
+  // 'heapOptions' on 'type' iff 'fiberNode' represents a functional component, i.e. there is no
+  // 'stateNode'.
   if (
     fiberNode.stateNode &&
     fiberNode.stateNode.heapOptions &&


### PR DESCRIPTION
Currently, there is no way to attach prop capture configs to functional components, since we look for `heapOptions` on `stateNode`s, which do not exist on functional component instances.

With a functional component like
```
const Foo = (props) => {
  return (
    <some jsx>
  );
};
```
a `heapOptions` object can now be added by doing
```
Foo.heapOptions = {
   <options>
}
```
This would lead to `heapOptions` showing up on the `fiberNode.type` object.

While it's technically possible to allow this for class components, doing so could be potentially error-prone, since it would provide two different ways to declare heap options that wouldn't be close to each other in code.  E.g. a dev might add heap options as a static prop on a class component when heap options already exist through `Foo.heapOptions = {...}` without even realizing it.

Note: Because of the `npm start` issue with `TestDriver` on my machine, e2e tests have **not** been run.  These should still be run before merging (although I don't expect any issues).