### PR TITLE
[HEAP-8030] Allowing either specifying an entire nested object, or by flattened key.

### DIFF
--- a/js/util/__tests__/extractProps.spec.ts
+++ b/js/util/__tests__/extractProps.spec.ts
@@ -24,6 +24,25 @@ describe('Extracting Props with a configuration', () => {
     },
   };
 
+  const objWithNestedObject = _.merge({}, obj1, {
+    stateNode: {
+      props: {
+        a: {
+          innerKey: 'kwikset',
+          innerNumber: 42,
+        },
+      },
+    },
+  });
+
+  const objectWithNestedArray = _.merge({}, obj1, {
+    stateNode: {
+      props: {
+        a: [3, 4, 5],
+      },
+    },
+  });
+
   const config: PropExtractorConfig = {
     Element: {
       include: ['a', 'c'],
@@ -74,32 +93,34 @@ describe('Extracting Props with a configuration', () => {
   });
 
   test('nested objects flatten properly', () => {
-    const obj2 = _.merge({}, obj1, {
-      stateNode: {
-        props: {
-          a: {
-            innerKey: 'kwikset',
-          },
-        },
-      },
+    expect(extractProps('Element', objWithNestedObject, config)).toEqual(
+      '[a.innerKey=kwikset];[a.innerNumber=42];[c=true];'
+    );
+  });
+
+  test('can extract an attribute of a nested object', () => {
+    const config2 = _.merge({}, config, {
+      Element: { include: ['a.innerKey'] },
     });
 
-    expect(extractProps('Element', obj2, config)).toEqual(
+    expect(extractProps('Element', objWithNestedObject, config2)).toEqual(
       '[a.innerKey=kwikset];[c=true];'
     );
   });
 
   test('arrays flatten properly', () => {
-    const obj2 = _.merge({}, obj1, {
-      stateNode: {
-        props: {
-          a: [3, 4, 5],
-        },
-      },
+    expect(extractProps('Element', objectWithNestedArray, config)).toEqual(
+      '[a.0=3];[a.1=4];[a.2=5];[c=true];'
+    );
+  });
+
+  test('can extract a single element of an array', () => {
+    const config2 = _.merge({}, config, {
+      Element: { include: ['a.1'] },
     });
 
-    expect(extractProps('Element', obj2, config)).toEqual(
-      '[a.0=3];[a.1=4];[a.2=5];[c=true];'
+    expect(extractProps('Element', objectWithNestedArray, config2)).toEqual(
+      '[a.1=4];[c=true];'
     );
   });
 

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -107,7 +107,6 @@ export const extractProps = (
   const secondPassProps = flatten(pick(flattenedProps, inclusionList));
 
   const combinedProps = { ...firstPassFilteredProps, ...secondPassProps };
-
   const sortedKeys = Object.keys(combinedProps).sort();
 
   // Only include props that are primitives.


### PR DESCRIPTION
@jnatkins raised the point that we might want to allow users to specify sub-attributes of nested components piecemeal, instead of specifying that we want the entire nested object.  This requires a two-pass approach on grabbing the props (since we didn't actually want to lose the other behavior either).  The first pass grabs the whole object, and then after the input object is flattened, we make another pass and combine the two for the end result.