### PR TITLE
[HEAP-8030] Allowing specifying prop by flattened key path

### DIFF
--- a/js/util/__tests__/extractProps.spec.ts
+++ b/js/util/__tests__/extractProps.spec.ts
@@ -24,6 +24,31 @@ describe('Extracting Props with a configuration', () => {
     },
   };
 
+  const objWithNestedObject = _.merge({}, obj1, {
+    stateNode: {
+      props: {
+        a: {
+          innerKey: 'kwikset',
+          innerNumber: 42,
+        },
+        b: {
+          c: {
+            bar: 'asdf',
+            foo: 'fdsa',
+          },
+        },
+      },
+    },
+  });
+
+  const objectWithNestedArray = _.merge({}, obj1, {
+    stateNode: {
+      props: {
+        a: [3, 4, 5],
+      },
+    },
+  });
+
   const config: PropExtractorConfig = {
     Element: {
       include: ['a', 'c'],
@@ -74,32 +99,34 @@ describe('Extracting Props with a configuration', () => {
   });
 
   test('nested objects flatten properly', () => {
-    const obj2 = _.merge({}, obj1, {
-      stateNode: {
-        props: {
-          a: {
-            innerKey: 'kwikset',
-          },
-        },
-      },
+    expect(extractProps('Element', objWithNestedObject, config)).toEqual(
+      '[a.innerKey=kwikset];[a.innerNumber=42];[c=true];'
+    );
+  });
+
+  test('can extract an attribute of a nested object', () => {
+    const config2 = _.merge({}, config, {
+      Element: { include: ['a.innerKey', 'b.c', 'c'] },
     });
 
-    expect(extractProps('Element', obj2, config)).toEqual(
-      '[a.innerKey=kwikset];[c=true];'
+    expect(extractProps('Element', objWithNestedObject, config2)).toEqual(
+      '[a.innerKey=kwikset];[b.c.bar=asdf];[b.c.foo=fdsa];[c=true];'
     );
   });
 
   test('arrays flatten properly', () => {
-    const obj2 = _.merge({}, obj1, {
-      stateNode: {
-        props: {
-          a: [3, 4, 5],
-        },
-      },
+    expect(extractProps('Element', objectWithNestedArray, config)).toEqual(
+      '[a.0=3];[a.1=4];[a.2=5];[c=true];'
+    );
+  });
+
+  test('can extract a single element of an array', () => {
+    const config2 = _.merge({}, config, {
+      Element: { include: ['a.1'] },
     });
 
-    expect(extractProps('Element', obj2, config)).toEqual(
-      '[a.0=3];[a.1=4];[a.2=5];[c=true];'
+    expect(extractProps('Element', objectWithNestedArray, config2)).toEqual(
+      '[a.1=4];[c=true];'
     );
   });
 

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -1,6 +1,6 @@
 import { getCombinedInclusionList } from './combineConfigs';
 
-const pick = require('lodash.pick');
+const _ = require('lodash');
 const flatten = require('flat');
 
 export interface StateNode {
@@ -84,7 +84,7 @@ export const extractProps = (
     props = fiberNode.memoizedProps;
   }
 
-  const filteredProps = pick(props, inclusionList);
+  const filteredProps = _.pick(props, inclusionList);
   const flattenedProps = flatten(filteredProps);
   let propsString = '';
 


### PR DESCRIPTION
See https://github.com/heap/react-native-heap/pull/38 for additional context.

`pick` from the `lodash` package has different behavior than `lodash.pick`.  This behavior does what we prefer for allowing props to be included by key path, so we can use that instead.