### PR TITLE
Use `type` instead of `elementType` for targetText

### DIFF
--- a/js/Heap.js
+++ b/js/Heap.js
@@ -60,7 +60,7 @@ export default {
 
 // :TODO: (jmtaber129): Consider implementing sibling target text.
 const getTargetText = fiberNode => {
-  if (fiberNode.elementType === 'RCTText') {
+  if (fiberNode.type === 'RCTText') {
     return fiberNode.memoizedProps.children;
   }
 


### PR DESCRIPTION
Some versions of fiber don't have `elementType`, but they generally seem to have `type`, so use that instead