### PR TITLE
Add autotrack support for React Navigation

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -215,7 +215,7 @@ describe('Basic React Native and Touchable Support', () => {
   describe('Autotrack', () => {
     it("should autotrack 'TouchableOpacity's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableOpacity;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableOpacity;[testID=touchableOpacityText];|';
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -226,7 +226,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableHighlight's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableHighlight;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableHighlight;[testID=touchableHighlightText];|';
       const expectedTargetText = 'Touchable Highlight';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -237,7 +237,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableWithoutFeedback;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|';
       const expectedTargetText = 'Touchable Without Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -248,7 +248,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableNativeFeedback;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|';
       const expectedTargetText = 'Touchable Native Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -215,7 +215,7 @@ describe('Basic React Native and Touchable Support', () => {
   describe('Autotrack', () => {
     it("should autotrack 'TouchableOpacity's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableOpacity;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableOpacity;|';
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -226,7 +226,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableHighlight's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableHighlight;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableHighlight;|';
       const expectedTargetText = 'Touchable Highlight';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -237,7 +237,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableWithoutFeedback;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableWithoutFeedback;|';
       const expectedTargetText = 'Touchable Without Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -248,7 +248,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableNativeFeedback;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableNativeFeedback;|';
       const expectedTargetText = 'Touchable Native Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -5,8 +5,8 @@ assert = require('should/as-function');
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
-const IOS_BUTTON_SUFFIX = 'TouchableOpacity;|';
-const ANDROID_BUTTON_SUFFIX = 'TouchableNativeFeedback;|';
+const IOS_BUTTON_SUFFIX = 'TouchableOpacity;';
+const ANDROID_BUTTON_SUFFIX = 'TouchableNativeFeedback;';
 
 const doTestActions = async () => {
   // Open the PropExtraction tab in the tab navigator.
@@ -40,7 +40,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with class components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[title=testButtonTitle1];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[testID=button1];[title=testButtonTitle1];|${buttonSuffix}[testID=button1];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle1'
@@ -53,7 +53,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with stateless components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[title=testButtonTitle2];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[testID=button2];[title=testButtonTitle2];|${buttonSuffix}[testID=button2];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle2'
@@ -68,7 +68,7 @@ describe('Property Extraction in Hierarchies', () => {
     it('properly excludes properties', async () => {
       // The important thing for this test is that the first mention of 'Button' does NOT include the title property.
       // This is because the first one is a custom class that specifically excludes (while the second one is the built-in Button.)
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Button;|Button;[title=testButtonTitle3];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Button;|Button;[testID=button3];[title=testButtonTitle3];|${buttonSuffix}[testID=button3];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle3'

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -40,7 +40,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with class components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[title=testButtonTitle1];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[title=testButtonTitle1];|${buttonSuffix}`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle1'
@@ -53,7 +53,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with stateless components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[title=testButtonTitle2];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[title=testButtonTitle2];|${buttonSuffix}`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle2'
@@ -68,7 +68,7 @@ describe('Property Extraction in Hierarchies', () => {
     it('properly excludes properties', async () => {
       // The important thing for this test is that the first mention of 'Button' does NOT include the title property.
       // This is because the first one is a custom class that specifically excludes (while the second one is the built-in Button.)
-      const expectedHierarchy = `AppContainer;|App;|Provider;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Button;|Button;[title=testButtonTitle3];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Button;|Button;[title=testButtonTitle3];|${buttonSuffix}`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle3'

--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -146,12 +146,11 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-gesture-handler')
-    compile project(':@heap_react-native-heap')
+    implementation project(':react-native-gesture-handler')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
-    implementation project(':react-native-heap')
+    implementation project(':@heap_react-native-heap')
     androidTestImplementation(project(path: ":detox"))
     androidTestImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'

--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -146,6 +146,8 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-gesture-handler')
+    compile project(':@heap_react-native-heap')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules

--- a/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
+++ b/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
@@ -9,7 +9,6 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
-import com.heapanalytics.reactnative.RNHeapLibraryPackage;
 
 import java.util.Arrays;
 import java.util.List;
@@ -25,10 +24,9 @@ public class MainApplication extends Application implements ReactApplication {
     @Override
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
-              new MainReactPackage(),
-            new RNGestureHandlerPackage(),
-            new RNHeapLibraryPackage(),
-              new RNHeapLibraryPackage()
+        new MainReactPackage(),
+        new RNGestureHandlerPackage(),
+        new RNHeapLibraryPackage()
       );
     }
 

--- a/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
+++ b/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
@@ -3,6 +3,8 @@ package com.testdriver;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
+import com.heapanalytics.reactnative.RNHeapLibraryPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -24,6 +26,8 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
               new MainReactPackage(),
+            new RNGestureHandlerPackage(),
+            new RNHeapLibraryPackage(),
               new RNHeapLibraryPackage()
       );
     }

--- a/examples/TestDriver/android/settings.gradle
+++ b/examples/TestDriver/android/settings.gradle
@@ -1,4 +1,8 @@
 rootProject.name = 'TestDriver'
+include ':react-native-gesture-handler'
+project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
+include ':@heap_react-native-heap'
+project(':@heap_react-native-heap').projectDir = new File(rootProject.projectDir, '../node_modules/@heap/react-native-heap/android')
 
 include ':app'
 

--- a/examples/TestDriver/android/settings.gradle
+++ b/examples/TestDriver/android/settings.gradle
@@ -8,7 +8,3 @@ include ':app'
 
 include ':detox'
 project(':detox').projectDir = new File(rootProject.projectDir, '../node_modules/detox/android/detox')
-
-include ':react-native-heap'
-project(':react-native-heap').projectDir =
-        new File(rootProject.projectDir, '../node_modules/@heap/react-native-heap/android')

--- a/examples/TestDriver/ios/Podfile
+++ b/examples/TestDriver/ios/Podfile
@@ -32,6 +32,8 @@ target "TestDriver" do
 
   pod "react-native-heap", path: "../node_modules/@heap/react-native-heap"
 
+  pod 'RNGestureHandler', :path => '../node_modules/react-native-gesture-handler'
+
   target "TestDriverTests" do
     inherit! :search_paths
   end

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -57,6 +57,8 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
+  - RNGestureHandler (1.0.17):
+    - React
   - yoga (0.57.5.React)
 
 DEPENDENCIES:
@@ -77,6 +79,7 @@ DEPENDENCIES:
   - React/RCTText (from `../node_modules/react-native`)
   - React/RCTVibration (from `../node_modules/react-native`)
   - React/RCTWebSocket (from `../node_modules/react-native`)
+  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - yoga (from `../node_modules/react-native/ReactCommon/yoga/yoga.podspec`)
 
 SPEC REPOS:
@@ -95,6 +98,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native"
   react-native-heap:
     :path: "../node_modules/@heap/react-native-heap"
+  RNGestureHandler:
+    :path: "../node_modules/react-native-gesture-handler"
   yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga/yoga.podspec"
 
@@ -106,8 +111,9 @@ SPEC CHECKSUMS:
   Heap: 542282698e895bf511429e87e213ad863faabd5d
   React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
   react-native-heap: 720108c6585d0dedcc9fdca9ee336cd4758c3655
+  RNGestureHandler: afde2addc517e85cc97a25bfe119acbee779a7ce
   yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
-PODFILE CHECKSUM: 031f5b2ee87bbde2dafea76a1ae7d594d34e7755
+PODFILE CHECKSUM: 94963ca9da08a6f38a9019eb8da64ec0f890b712
 
 COCOAPODS: 1.5.3

--- a/examples/TestDriver/ios/TestDriver.xcodeproj/project.pbxproj
+++ b/examples/TestDriver/ios/TestDriver.xcodeproj/project.pbxproj
@@ -396,6 +396,7 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/DoubleConversion/DoubleConversion.framework",
 				"${BUILT_PRODUCTS_DIR}/Folly/folly.framework",
+				"${BUILT_PRODUCTS_DIR}/RNGestureHandler/RNGestureHandler.framework",
 				"${BUILT_PRODUCTS_DIR}/React/React.framework",
 				"${BUILT_PRODUCTS_DIR}/glog/glog.framework",
 				"${BUILT_PRODUCTS_DIR}/yoga/yoga.framework",
@@ -406,6 +407,7 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DoubleConversion.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/folly.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNGestureHandler.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",

--- a/examples/TestDriver/ios/TestDriver/AppDelegate.m
+++ b/examples/TestDriver/ios/TestDriver/AppDelegate.m
@@ -33,10 +33,10 @@
   [self.window makeKeyAndVisible];
 
   // Send events to local collector.
-//  SEL setRootUrlSelector = @selector(setRootUrl:);
-//  if ([[Heap class] respondsToSelector:setRootUrlSelector]) {
-//    [[Heap class] performSelector:setRootUrlSelector withObject:@"http://localhost:3000"];
-//  }
+  SEL setRootUrlSelector = @selector(setRootUrl:);
+  if ([[Heap class] respondsToSelector:setRootUrlSelector]) {
+    [[Heap class] performSelector:setRootUrlSelector withObject:@"http://localhost:3000"];
+  }
 
   return YES;
 }

--- a/examples/TestDriver/ios/TestDriver/AppDelegate.m
+++ b/examples/TestDriver/ios/TestDriver/AppDelegate.m
@@ -33,10 +33,10 @@
   [self.window makeKeyAndVisible];
 
   // Send events to local collector.
-  SEL setRootUrlSelector = @selector(setRootUrl:);
-  if ([[Heap class] respondsToSelector:setRootUrlSelector]) {
-    [[Heap class] performSelector:setRootUrlSelector withObject:@"http://localhost:3000"];
-  }
+//  SEL setRootUrlSelector = @selector(setRootUrl:);
+//  if ([[Heap class] respondsToSelector:setRootUrlSelector]) {
+//    [[Heap class] performSelector:setRootUrlSelector withObject:@"http://localhost:3000"];
+//  }
 
   return YES;
 }

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "./preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.2.0-alpha2.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.2.0-alpha3.tgz",
     "react": "16.6.1",
     "react-native": "0.57.5",
     "react-navigation": "^3.3.2",

--- a/examples/TestDriver/src/topNavigator.js
+++ b/examples/TestDriver/src/topNavigator.js
@@ -14,4 +14,6 @@ const TabNavigator = createBottomTabNavigator({
   PropExtraction: PropExtraction,
 });
 
-export default createAppContainer(TabNavigator);
+export default Heap.withReactNavigationAutotrack(
+  createAppContainer(TabNavigator)
+);

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -1,7 +1,9 @@
 // Libraries
-import { NativeModules, Platform } from 'react-native';
-import { extractProps } from './util/extractProps';
-import { builtinPropExtractorConfig } from './propExtractorConfig';
+import React from 'react';
+import { NativeModules } from 'react-native';
+
+import { autotrackPress } from './autotrack/touchables';
+import { withReactNavigationAutotrack } from './autotrack/reactNavigation';
 
 let flatten = require('flat');
 
@@ -35,94 +37,6 @@ export default {
     next(action);
   },
 
-  autotrackPress: (eventType, componentThis, event) => {
-    const touchableHierarchy = getComponentHierarchy(componentThis);
-    const touchState =
-      componentThis &&
-      componentThis.state &&
-      componentThis.state.touchable &&
-      componentThis.state.touchable.touchState;
-
-    const targetText = getTargetText(componentThis._reactInternalFiber);
-
-    const autotrackProps = {
-      touchableHierarchy,
-      touchState,
-    };
-
-    if (targetText !== '') {
-      autotrackProps.targetText = targetText;
-    }
-
-    track(eventType, autotrackProps);
-  },
-};
-
-// :TODO: (jmtaber129): Consider implementing sibling target text.
-const getTargetText = fiberNode => {
-  if (fiberNode.type === 'RCTText') {
-    return fiberNode.memoizedProps.children;
-  }
-
-  if (fiberNode.child === null) {
-    return '';
-  }
-
-  const children = [];
-  let currChild = fiberNode.child;
-  while (currChild) {
-    children.push(currChild);
-    currChild = currChild.sibling;
-  }
-
-  let targetText = '';
-  children.forEach(child => {
-    targetText = (targetText + ' ' + getTargetText(child)).trim();
-  });
-  return targetText;
-};
-
-const getComponentHierarchy = componentThis => {
-  // :TODO: (jmtaber129): Remove this if/when we support pre-fiber React.
-  if (!componentThis._reactInternalFiber) {
-    throw new Error(
-      'Pre-fiber React versions (React 16) are currently not supported by Heap autotrack.'
-    );
-  }
-
-  return getFiberNodeComponentHierarchy(componentThis._reactInternalFiber);
-};
-
-const getFiberNodeComponentHierarchy = currNode => {
-  if (currNode === null) {
-    return '';
-  }
-
-  // Skip components we don't care about.
-  // :TODO: (jmtaber129): Skip components with names/display names like 'View' and '_class'.
-  if (
-    currNode.type === 'RCTView' ||
-    currNode.type === null ||
-    !(currNode.type.displayName || currNode.type.name)
-  ) {
-    return getFiberNodeComponentHierarchy(currNode.return);
-  }
-
-  const elementName = currNode.type.displayName || currNode.type.name;
-
-  // In dev builds, 'View' components remain in the fiber tree, but don't provide any useful
-  // information, so exclude these from the hierarchy.
-  if (elementName === 'View') {
-    return getFiberNodeComponentHierarchy(currNode.return);
-  }
-
-  const propsString = extractProps(
-    elementName,
-    currNode,
-    builtinPropExtractorConfig
-  );
-
-  return `${getFiberNodeComponentHierarchy(
-    currNode.return
-  )}${elementName};${propsString}|`;
+  autotrackPress: autotrackPress(track),
+  withReactNavigationAutotrack: withReactNavigationAutotrack(track),
 };

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -1,0 +1,58 @@
+import React from 'react';
+
+const EVENT_TYPE = 'reactNavigationScreenview';
+
+export const withReactNavigationAutotrack = track => AppContainer => {
+  return class HeapNavigationWrapper extends React.Component {
+    topLevelNavigator = null;
+
+    trackInitialRoute() {
+      const initialPageviewPath = getActiveRouteName(
+        this.topLevelNavigator.state.nav
+      );
+
+      track(EVENT_TYPE, {
+        path: initialPageviewPath,
+      });
+    }
+
+    render() {
+      return (
+        <AppContainer
+          ref={navigatorRef => {
+            if (this.topLevelNavigator !== navigatorRef) {
+              this.topLevelNavigator = navigatorRef;
+              this.trackInitialRoute();
+            }
+          }}
+          onNavigationStateChange={(prev, next, action) => {
+            const prevScreenRoute = getActiveRouteName(prev);
+            const nextScreenRoute = getActiveRouteName(next);
+            if (prevScreenRoute !== nextScreenRoute) {
+              const currentScreen = getActiveRouteName(next);
+              track(EVENT_TYPE, {
+                path: currentScreen,
+                type: action.type,
+              });
+            }
+          }}
+        >
+          {this.props.children}
+        </AppContainer>
+      );
+    }
+  };
+};
+
+const getActiveRouteName = navigationState => {
+  if (!navigationState) {
+    return null;
+  }
+  const route = navigationState.routes[navigationState.index];
+  // dive into nested navigators
+  if (route.routes) {
+    return `${route.routeName}::${getActiveRouteName(route)}`;
+  }
+
+  return route.routeName;
+};

--- a/js/autotrack/touchables.js
+++ b/js/autotrack/touchables.js
@@ -1,0 +1,93 @@
+import { extractProps } from '../util/extractProps';
+import { builtinPropExtractorConfig } from '../propExtractorConfig';
+
+export const autotrackPress = track => (eventType, componentThis, event) => {
+  const touchableHierarchy = getComponentHierarchy(componentThis);
+  const touchState =
+    componentThis &&
+    componentThis.state &&
+    componentThis.state.touchable &&
+    componentThis.state.touchable.touchState;
+
+  const targetText = getTargetText(componentThis._reactInternalFiber);
+
+  const autotrackProps = {
+    touchableHierarchy,
+    touchState,
+  };
+
+  if (targetText !== '') {
+    autotrackProps.targetText = targetText;
+  }
+
+  track(eventType, autotrackProps);
+};
+
+const getComponentHierarchy = componentThis => {
+  // :TODO: (jmtaber129): Remove this if/when we support pre-fiber React.
+  if (!componentThis._reactInternalFiber) {
+    throw new Error(
+      'Pre-fiber React versions (React 16) are currently not supported by Heap autotrack.'
+    );
+  }
+
+  return getFiberNodeComponentHierarchy(componentThis._reactInternalFiber);
+};
+
+const getFiberNodeComponentHierarchy = currNode => {
+  if (currNode === null) {
+    return '';
+  }
+
+  // Skip components we don't care about.
+  // :TODO: (jmtaber129): Skip components with names/display names like 'View' and '_class'.
+  if (
+    currNode.type === 'RCTView' ||
+    currNode.type === null ||
+    !(currNode.type.displayName || currNode.type.name)
+  ) {
+    return getFiberNodeComponentHierarchy(currNode.return);
+  }
+
+  const elementName = currNode.type.displayName || currNode.type.name;
+
+  // In dev builds, 'View' components remain in the fiber tree, but don't provide any useful
+  // information, so exclude these from the hierarchy.
+  if (elementName === 'View') {
+    return getFiberNodeComponentHierarchy(currNode.return);
+  }
+
+  const propsString = extractProps(
+    elementName,
+    currNode,
+    builtinPropExtractorConfig
+  );
+
+  return `${getFiberNodeComponentHierarchy(
+    currNode.return
+  )}${elementName};${propsString}|`;
+};
+
+// :TODO: (jmtaber129): Consider implementing sibling target text.
+const getTargetText = fiberNode => {
+  if (fiberNode.type === 'RCTText') {
+    return fiberNode.memoizedProps.children;
+  }
+
+  if (fiberNode.child === null) {
+    return '';
+  }
+
+  const children = [];
+  let currChild = fiberNode.child;
+  while (currChild) {
+    children.push(currChild);
+    currChild = currChild.sibling;
+  }
+
+  let targetText = '';
+  children.forEach(child => {
+    targetText = (targetText + ' ' + getTargetText(child)).trim();
+  });
+  return targetText;
+};

--- a/js/propExtractorConfig.ts
+++ b/js/propExtractorConfig.ts
@@ -1,6 +1,10 @@
 import { PropExtractorConfig } from './util/extractProps';
 
 const builtinPropExtractorConfig: PropExtractorConfig = {
+  '*': {
+    include: ['testID'],
+    exclude: [],
+  },
   Button: {
     include: ['title'],
     exclude: [],

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -69,9 +69,11 @@ export const extractProps = (
       .eventProps as PropExtractorCriteria;
   }
 
+  const wildcardCriteria = config['*'] || EMPTY_CRITERIA;
   const builtInCriteria = config[elementName] || EMPTY_CRITERIA;
 
   const inclusionList = getCombinedInclusionList([
+    wildcardCriteria,
     builtInCriteria,
     classCriteria,
   ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.2.0-alpha2",
+  "version": "0.2.0-alpha3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.2.0-alpha2",
+  "version": "0.2.0-alpha3",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
This PR adds the ability wrap a React Navigation AppContainer with a Heap component and autotrack any changes in the route.  This also refactors the existing autotrack for Touchables into its own module so the main Heap module stays tidy.
- Version bump to 0.2.0-alpha3