### PR TITLE
Add wildcard config, and extract testID

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -215,7 +215,7 @@ describe('Basic React Native and Touchable Support', () => {
   describe('Autotrack', () => {
     it("should autotrack 'TouchableOpacity's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableOpacity;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableOpacity;[testID=touchableOpacityText];|';
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -226,7 +226,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableHighlight's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableHighlight;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableHighlight;[testID=touchableHighlightText];|';
       const expectedTargetText = 'Touchable Highlight';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -237,7 +237,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableWithoutFeedback;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|';
       const expectedTargetText = 'Touchable Without Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -248,7 +248,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableNativeFeedback;|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|';
       const expectedTargetText = 'Touchable Native Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -5,8 +5,8 @@ assert = require('should/as-function');
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
-const IOS_BUTTON_SUFFIX = 'TouchableOpacity;|';
-const ANDROID_BUTTON_SUFFIX = 'TouchableNativeFeedback;|';
+const IOS_BUTTON_SUFFIX = 'TouchableOpacity;';
+const ANDROID_BUTTON_SUFFIX = 'TouchableNativeFeedback;';
 
 const doTestActions = async () => {
   // Open the PropExtraction tab in the tab navigator.
@@ -40,7 +40,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with class components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[title=testButtonTitle1];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[testID=button1];[title=testButtonTitle1];|${buttonSuffix}[testID=button1];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle1'
@@ -53,7 +53,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with stateless components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[title=testButtonTitle2];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[testID=button2];[title=testButtonTitle2];|${buttonSuffix}[testID=button2];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle2'
@@ -68,7 +68,7 @@ describe('Property Extraction in Hierarchies', () => {
     it('properly excludes properties', async () => {
       // The important thing for this test is that the first mention of 'Button' does NOT include the title property.
       // This is because the first one is a custom class that specifically excludes (while the second one is the built-in Button.)
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Button;|Button;[title=testButtonTitle3];|${buttonSuffix}`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Button;|Button;[testID=button3];[title=testButtonTitle3];|${buttonSuffix}[testID=button3];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle3'

--- a/examples/TestDriver/ios/TestDriver/AppDelegate.m
+++ b/examples/TestDriver/ios/TestDriver/AppDelegate.m
@@ -33,10 +33,10 @@
   [self.window makeKeyAndVisible];
 
   // Send events to local collector.
-//  SEL setRootUrlSelector = @selector(setRootUrl:);
-//  if ([[Heap class] respondsToSelector:setRootUrlSelector]) {
-//    [[Heap class] performSelector:setRootUrlSelector withObject:@"http://localhost:3000"];
-//  }
+  SEL setRootUrlSelector = @selector(setRootUrl:);
+  if ([[Heap class] respondsToSelector:setRootUrlSelector]) {
+    [[Heap class] performSelector:setRootUrlSelector withObject:@"http://localhost:3000"];
+  }
 
   return YES;
 }

--- a/js/propExtractorConfig.ts
+++ b/js/propExtractorConfig.ts
@@ -1,6 +1,10 @@
 import { PropExtractorConfig } from './util/extractProps';
 
 const builtinPropExtractorConfig: PropExtractorConfig = {
+  '*': {
+    include: ['testID'],
+    exclude: [],
+  },
   Button: {
     include: ['title'],
     exclude: [],

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -69,9 +69,11 @@ export const extractProps = (
       .eventProps as PropExtractorCriteria;
   }
 
+  const wildcardCriteria = config['*'] || EMPTY_CRITERIA;
   const builtInCriteria = config[elementName] || EMPTY_CRITERIA;
 
   const inclusionList = getCombinedInclusionList([
+    wildcardCriteria,
     builtInCriteria,
     classCriteria,
   ]);


### PR DESCRIPTION
Adds a wildcard category to the built-in property extractor configuration so that we can extract testID on any component that has one.