### PR TITLE
Add detox e2e tests for React Navigation

### DIFF
--- a/e2e/00_initial.spec.js
+++ b/e2e/00_initial.spec.js
@@ -1,0 +1,24 @@
+require('coffeescript').register();
+_ = require('lodash');
+assert = require('should/as-function');
+
+testUtil = require('../../heap/test/util');
+rnTestUtil = require('./rnTestUtilities');
+
+// This file is named funkily so that Mocha runs this first.  That way we
+// don't lose the initial navigation event (each test flushes redis).
+
+describe('Initial Navigation', () => {
+  before(async () => {
+    await device.launchApp();
+
+    await expect(element(by.id('initialSentinel'))).toBeVisible();
+    await element(by.id('initialSentinel')).tap();
+
+    await rnTestUtil.pollForSentinel('Initial');
+  });
+
+  it('tracks the initial route', async () => {
+    await rnTestUtil.assertNavigationEvent('Initial');
+  });
+});

--- a/e2e/00_initial.spec.js
+++ b/e2e/00_initial.spec.js
@@ -1,6 +1,4 @@
 require('coffeescript').register();
-_ = require('lodash');
-assert = require('should/as-function');
 
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -26,13 +26,11 @@ const doTestActions = async () => {
   if (device.getPlatform() === 'android') {
     await element(by.id('touchableNativeFeedbackText')).tap();
   }
+
+  await element(by.id('basicsSentinel')).tap();
 };
 
 describe('Basic React Native and Touchable Support', () => {
-  before(async () => {
-    await device.launchApp();
-  });
-
   before(done => {
     db.orm.connection.sharedRedis().flushall(done);
   });
@@ -40,7 +38,7 @@ describe('Basic React Native and Touchable Support', () => {
   describe(':ios: Bridge API', () => {
     before(async () => {
       await doTestActions();
-      await rnTestUtil.waitForEventsToFlush();
+      await rnTestUtil.pollForSentinel('Basics');
     });
 
     it('should call first track', async () => {
@@ -120,7 +118,7 @@ describe('Basic React Native and Touchable Support', () => {
   describe(':android: Bridge API', () => {
     before(async () => {
       await doTestActions();
-      await rnTestUtil.waitForEventsToFlush();
+      await rnTestUtil.pollForSentinel('Basics');
     });
 
     it('should call first track', async () => {
@@ -215,7 +213,7 @@ describe('Basic React Native and Touchable Support', () => {
   describe('Autotrack', () => {
     it("should autotrack 'TouchableOpacity's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableOpacity;[testID=touchableOpacityText];|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableOpacity;[testID=touchableOpacityText];|';
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -226,7 +224,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableHighlight's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableHighlight;[testID=touchableHighlightText];|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableHighlight;[testID=touchableHighlightText];|';
       const expectedTargetText = 'Touchable Highlight';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -237,7 +235,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|';
       const expectedTargetText = 'Touchable Without Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -248,7 +246,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(TouchablesPage);|TouchablesPage;|TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|';
       const expectedTargetText = 'Touchable Native Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',

--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -46,6 +46,7 @@ describe('Navigation', () => {
         'Navigation/NAVIGATE'
       );
     });
+
     it('tracks a stack navigator action', async () => {
       await rnTestUtil.assertNavigationEvent(
         'Nav::MainStack::StackCard',

--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -1,0 +1,68 @@
+require('coffeescript').register();
+_ = require('lodash');
+assert = require('should/as-function');
+
+testUtil = require('../../heap/test/util');
+rnTestUtil = require('./rnTestUtilities');
+
+const delay = async () => {
+  await new Promise(resolve => setTimeout(resolve, 500));
+};
+
+const doTestActions = async () => {
+  // Open the PropExtraction tab in the tab navigator.
+  await element(by.id('Nav')).tap();
+
+  await expect(element(by.id('navigate_stack'))).toBeVisible();
+  await element(by.id('navigate_stack')).tap();
+  await delay();
+  await expect(element(by.id('pop1'))).toBeVisible();
+  await element(by.id('pop1')).tap();
+  await delay();
+  await expect(element(by.id('navigate_modal'))).toBeVisible();
+  await element(by.id('navigate_modal')).tap();
+  await delay();
+  await expect(element(by.id('pop2'))).toBeVisible();
+  await element(by.id('pop2')).tap();
+  await delay();
+
+  await element(by.id('navSentinel')).tap();
+};
+
+describe('Navigation', () => {
+  before(done => {
+    db.orm.connection.sharedRedis().flushall(done);
+  });
+
+  describe('React Navigation autotrack', () => {
+    before(async () => {
+      await doTestActions();
+      await rnTestUtil.pollForSentinel('Nav');
+    });
+
+    it('tracks a tab navigator action', async () => {
+      await rnTestUtil.assertNavigationEvent(
+        'Nav::MainStack::Base',
+        'Navigation/NAVIGATE'
+      );
+    });
+    it('tracks a stack navigator action', async () => {
+      await rnTestUtil.assertNavigationEvent(
+        'Nav::MainStack::StackCard',
+        'Navigation/NAVIGATE'
+      );
+
+      await rnTestUtil.assertNavigationEvent(
+        'Nav::MainStack::Base',
+        'Navigation/POP'
+      );
+    });
+
+    it('tracks a modal stack navigator action', async () => {
+      await rnTestUtil.assertNavigationEvent(
+        'Nav::ModalStack',
+        'Navigation/NAVIGATE'
+      );
+    });
+  });
+});

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -16,13 +16,14 @@ const doTestActions = async () => {
   await element(by.id('button1')).tap();
   await element(by.id('button2')).tap();
   await element(by.id('button3')).tap();
+
+  await element(by.id('propextractionSentinel')).tap();
 };
 
 describe('Property Extraction in Hierarchies', () => {
   let buttonSuffix = '';
 
   before(async () => {
-    await device.launchApp();
     buttonSuffix =
       device.getPlatform() === 'ios'
         ? IOS_BUTTON_SUFFIX
@@ -36,7 +37,7 @@ describe('Property Extraction in Hierarchies', () => {
   describe('The property extractor', () => {
     before(async () => {
       await doTestActions();
-      await rnTestUtil.waitForEventsToFlush();
+      await rnTestUtil.pollForSentinel('PropExtraction');
     });
 
     it('works with class components', async () => {

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -80,12 +80,116 @@ const assertAutotrackHierarchy = async (
   }
 };
 
+const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
+  let props = {
+    path: {
+      string: expectedPath,
+    },
+  };
+  if (expectedType) {
+    props = {
+      ...props,
+      type: {
+        string: expectedType,
+      },
+    };
+  }
+
+  return assertAndroidEvent({
+    envId: '2084764307',
+    event: {
+      custom: {
+        name: 'reactNavigationScreenview',
+        properties: props,
+      },
+    },
+  });
+};
+
+const assertIosNavigationEvent = async (expectedPath, expectedType) => {
+  let props = ['path', expectedPath];
+  if (expectedType) {
+    props = [...props, 'type', expectedType];
+  }
+  return assertIosPixel({
+    t: 'reactNavigationScreenview',
+    k: props,
+  });
+};
+
+const assertNavigationEvent = async (expectedPath, expectedType) => {
+  if (device.getPlatform() === 'android') {
+    return assertAndroidNavigationEvent(expectedPath, expectedType);
+  } else if (device.getPlatform() === 'ios') {
+    return assertIosNavigationEvent(expectedPath, expectedType);
+  } else {
+    throw new Error(`Unknown device type: ${device.getPlatform()}`);
+  }
+};
+
 waitForEventsToFlush = async () => {
-  // Heap for iOS and Android flushes events every 15 seconds. Wait 16 seconds to ensure that
-  // all events are flushed to redis before asserting.
-  // :TODO:(jmtaber129): Make this wait shorter if/when we expose setting the
-  // flush frequency to the RN bridge.
+  // Add a delay to wait for all events to flush to the server
   await new Promise(resolve => setTimeout(resolve, 16000));
+};
+
+pollForSentinel = async (sentinelValue, timeout = 60000) => {
+  console.log(
+    `--- Waiting for ${sentinelValue} sentinel event.  This will timeout in 60s ---`
+  );
+  const startTick = Date.now();
+
+  // Give it a few seconds at first.
+  await new Promise(resolve => setTimeout(resolve, 3000));
+
+  while (Date.now() - startTick <= timeout) {
+    const eventName = `${sentinelValue.toUpperCase()}_SENTINEL`;
+    if (device.getPlatform() === 'ios') {
+      const event = {
+        a: '2084764307',
+        t: eventName,
+      };
+
+      const { iosErr, iosRes } = await new Promise((resolve, reject) => {
+        testUtil.findEventInRedisRequests(event, (iosErr, iosRes) => {
+          resolve({ iosErr, iosRes });
+        });
+      });
+
+      if (iosRes.length != 0) {
+        return;
+      }
+    } else if (device.getPlatform() === 'android') {
+      const event = {
+        envId: '2084764307',
+        event: {
+          custom: {
+            name: eventName,
+          },
+        },
+      };
+
+      const { androidErr, androidRes } = await new Promise(
+        (resolve, reject) => {
+          testUtil.findAndroidEventInRedisRequests(
+            event,
+            (androidErr, androidRes) => {
+              resolve({ androidErr, androidRes });
+            }
+          );
+        }
+      );
+
+      if (androidRes.length != 0) {
+        return;
+      }
+    } else {
+      throw new Error(`Unknown device type: ${device.getPlatform()}`);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  throw new Error(`Timed out waiting for sentinel event ${sentinelValue}`);
 };
 
 module.exports = {
@@ -94,5 +198,7 @@ module.exports = {
   assertAndroidEvent,
   assertAndroidAutotrackHierarchy,
   assertAutotrackHierarchy,
+  assertNavigationEvent,
   waitForEventsToFlush,
+  pollForSentinel,
 };

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -127,11 +127,6 @@ const assertNavigationEvent = async (expectedPath, expectedType) => {
   }
 };
 
-waitForEventsToFlush = async () => {
-  // Add a delay to wait for all events to flush to the server
-  await new Promise(resolve => setTimeout(resolve, 16000));
-};
-
 pollForSentinel = async (sentinelValue, timeout = 60000) => {
   console.log(
     `--- Waiting for ${sentinelValue} sentinel event.  This will timeout in 60s ---`
@@ -199,6 +194,5 @@ module.exports = {
   assertAndroidAutotrackHierarchy,
   assertAutotrackHierarchy,
   assertNavigationEvent,
-  waitForEventsToFlush,
   pollForSentinel,
 };

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -2,6 +2,8 @@ require('coffeescript').register();
 db = require('../../heap/back/db');
 testUtil = require('../../heap/test/util');
 
+const HEAP_ENV_ID = '2084764307';
+
 const assertEvent = (err, res, check) => {
   assert.not.exist(err);
   assert(res.length).not.equal(0);
@@ -37,7 +39,7 @@ const assertAndroidAutotrackHierarchy = async (
   expectedTargetText
 ) => {
   return assertAndroidEvent({
-    envId: '2084764307',
+    envId: HEAP_ENV_ID,
     event: {
       custom: {
         name: expectedName,
@@ -81,22 +83,22 @@ const assertAutotrackHierarchy = async (
 };
 
 const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
-  let props = {
+  const commonProps = {
     path: {
       string: expectedPath,
     },
   };
-  if (expectedType) {
-    props = {
-      ...props,
-      type: {
-        string: expectedType,
-      },
-    };
-  }
+  const props = expectedType
+    ? {
+        ...commonProps,
+        type: {
+          string: expectedType,
+        },
+      }
+    : commonProps;
 
   return assertAndroidEvent({
-    envId: '2084764307',
+    envId: HEAP_ENV_ID,
     event: {
       custom: {
         name: 'reactNavigationScreenview',
@@ -107,10 +109,10 @@ const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
 };
 
 const assertIosNavigationEvent = async (expectedPath, expectedType) => {
-  let props = ['path', expectedPath];
-  if (expectedType) {
-    props = [...props, 'type', expectedType];
-  }
+  const commonProps = ['path', expectedPath];
+  const props = expectedType
+    ? [...commonProps, 'type', expectedType]
+    : commonProps;
   return assertIosPixel({
     t: 'reactNavigationScreenview',
     k: props,
@@ -140,7 +142,7 @@ pollForSentinel = async (sentinelValue, timeout = 60000) => {
     const eventName = `${sentinelValue.toUpperCase()}_SENTINEL`;
     if (device.getPlatform() === 'ios') {
       const event = {
-        a: '2084764307',
+        a: HEAP_ENV_ID,
         t: eventName,
       };
 
@@ -155,7 +157,7 @@ pollForSentinel = async (sentinelValue, timeout = 60000) => {
       }
     } else if (device.getPlatform() === 'android') {
       const event = {
-        envId: '2084764307',
+        envId: HEAP_ENV_ID,
         event: {
           custom: {
             name: eventName,

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -14,17 +14,9 @@ import { connect } from 'react-redux';
 
 import Heap from '@heap/react-native-heap';
 import { incrementAction, decrementAction } from '../reduxElements';
+import { makeSentinelButton } from '../sentinelUtilities';
 
-class TouchablesPage extends Component {
-  static navigationOptions = () => {
-    return {
-      title: 'Basics',
-      tabBarLabel: 'Basics',
-      tabBarAccessibilityLabel: 'Basics',
-      tabBarTestID: 'Basics',
-    };
-  };
-
+class BasicsPage extends Component {
   render() {
     return (
       <View style={styles.container}>
@@ -90,6 +82,7 @@ class TouchablesPage extends Component {
             <Text>Touchable Native Feedback</Text>
           </TouchableNativeFeedback>
         )}
+        {makeSentinelButton('Basics')}
       </View>
     );
   }
@@ -105,7 +98,7 @@ export default connect(
       onDecrement: amount => dispatch(decrementAction(amount)),
     };
   }
-)(TouchablesPage);
+)(BasicsPage);
 
 const styles = StyleSheet.create({
   container: {

--- a/examples/TestDriver/src/pages/initial.js
+++ b/examples/TestDriver/src/pages/initial.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { makeSentinelButton } from '../sentinelUtilities';
+
+export default class InitialPage extends Component {
+  render() {
+    return (
+      <View style={styles.container}>
+        <Text>react-native-heap TestDriver</Text>
+        {makeSentinelButton('Initial')}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+});

--- a/examples/TestDriver/src/pages/nav.js
+++ b/examples/TestDriver/src/pages/nav.js
@@ -1,0 +1,69 @@
+import React, { Component } from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { createStackNavigator } from 'react-navigation';
+
+import { makeSentinelButton } from '../sentinelUtilities';
+
+const BaseView = props => {
+  return (
+    <View style={styles.container}>
+      <Button
+        title="Navigate Stack"
+        testID="navigate_stack"
+        onPress={() => props.navigation.navigate('StackCard')}
+      />
+      <Button
+        title="Navigate Modal"
+        testID="navigate_modal"
+        onPress={() => props.navigation.navigate('ModalStack')}
+      />
+      {makeSentinelButton('Nav')}
+    </View>
+  );
+};
+
+const StackCardView = props => {
+  return (
+    <View style={styles.container}>
+      <Button
+        title="Pop1"
+        testID="pop1"
+        onPress={() => props.navigation.pop()}
+      />
+    </View>
+  );
+};
+
+const ModalCardView = props => {
+  return (
+    <View style={styles.container}>
+      <Button
+        title="Pop2"
+        testID="pop2"
+        onPress={() => props.navigation.pop()}
+      />
+    </View>
+  );
+};
+
+export default createStackNavigator(
+  {
+    MainStack: createStackNavigator({
+      Base: BaseView,
+      StackCard: StackCardView,
+    }),
+    ModalStack: {
+      screen: ModalCardView,
+    },
+  },
+  { mode: 'modal', headerMode: 'none' }
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+});

--- a/examples/TestDriver/src/pages/propExtraction.js
+++ b/examples/TestDriver/src/pages/propExtraction.js
@@ -1,6 +1,10 @@
 import React, { Component } from 'react';
 import { Button as BuiltInButton, StyleSheet, View } from 'react-native';
 
+import Heap from '@heap/react-native-heap';
+
+import { makeSentinelButton } from '../sentinelUtilities';
+
 class Container1 extends Component {
   heapOptions = { eventProps: { include: ['custom1'] } };
 
@@ -43,21 +47,13 @@ class Button extends Component {
 }
 
 export default class PropExtraction extends Component {
-  static navigationOptions = () => {
-    return {
-      title: 'PropExtraction',
-      tabBarLabel: 'PropExtraction',
-      tabBarAccessibilityLabel: 'PropExtraction',
-      tabBarTestID: 'PropExtraction',
-    };
-  };
-
   render() {
     return (
       <View style={styles.container}>
         <Container1 custom1="customProp1" />
         <Container2 custom2="customProp2" />
         <Button title="excludedProp" />
+        {makeSentinelButton('PropExtraction')}
       </View>
     );
   }

--- a/examples/TestDriver/src/sentinelUtilities.js
+++ b/examples/TestDriver/src/sentinelUtilities.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Button } from 'react-native';
+
+import Heap from '@heap/react-native-heap';
+
+export const makeSentinelTestID = key => {
+  return `${key.toLowerCase()}Sentinel`;
+};
+
+export const makeSentinelEventName = key => {
+  return `${key.toUpperCase()}_SENTINEL`;
+};
+
+export const makeSentinelButtonTitle = key => {
+  return `Send ${key} Sentinel`;
+};
+
+export const makeSentinelButton = key => {
+  return (
+    <Button
+      title={makeSentinelButtonTitle(key)}
+      testID={makeSentinelTestID(key)}
+      onPress={() => {
+        Heap.track(makeSentinelEventName(key));
+      }}
+    />
+  );
+};

--- a/examples/TestDriver/src/topNavigator.js
+++ b/examples/TestDriver/src/topNavigator.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import { createBottomTabNavigator, createAppContainer } from 'react-navigation';
 
+import InitialPage from './pages/initial';
 import BasicsPage from './pages/basics';
 import PropExtraction from './pages/propExtraction';
+import NavPage from './pages/nav';
 
 import Heap from '@heap/react-native-heap';
 
@@ -10,8 +12,42 @@ Heap.setAppId('2084764307');
 console.log('Heap App ID set');
 
 const TabNavigator = createBottomTabNavigator({
-  Basics: BasicsPage,
-  PropExtraction: PropExtraction,
+  Initial: {
+    screen: InitialPage,
+  },
+  Basics: {
+    screen: BasicsPage,
+    navigationOptions: () => {
+      return {
+        title: 'Basics',
+        tabBarLabel: 'Basics',
+        tabBarAccessibilityLabel: 'Basics',
+        tabBarTestID: 'Basics',
+      };
+    },
+  },
+  PropExtraction: {
+    screen: PropExtraction,
+    navigationOptions: () => {
+      return {
+        title: 'PropExtraction',
+        tabBarLabel: 'PropExtraction',
+        tabBarAccessibilityLabel: 'PropExtraction',
+        tabBarTestID: 'PropExtraction',
+      };
+    },
+  },
+  Nav: {
+    screen: NavPage,
+    navigationOptions: () => {
+      return {
+        title: 'Nav',
+        tabBarLabel: 'Nav',
+        tabBarAccessibilityLabel: 'Nav',
+        tabBarTestID: 'Nav',
+      };
+    },
+  },
 });
 
 export default Heap.withReactNavigationAutotrack(


### PR DESCRIPTION
The first commit refactors the existing tests slightly, renaming some of the files and moving the navigationOptions into a common spot in the navigator.  The second commit adds the tests for navigation, and the pages to support it.  To capture the initial navigation event, there is a new "initial" page with just a single test.