### PR TITLE
Vendoring native Heap lib instead of CP dependency

### DIFF
--- a/ios/RNHeap.xcodeproj/project.pbxproj
+++ b/ios/RNHeap.xcodeproj/project.pbxproj
@@ -7,23 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		21C146AB224AEB1500764BE4 /* libHeap.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 21E7F364224444E700270330 /* libHeap.a */; };
 		4DE526AA1ECD4A340059312E /* RNHeap.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DE526A91ECD4A340059312E /* RNHeap.m */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		112EE36B1CC0AB8A00BF6BB8 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		112EE36D1CC0AB8A00BF6BB8 /* libRNHeap.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNHeap.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		21E7F364224444E700270330 /* libHeap.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libHeap.a; sourceTree = "<group>"; };
+		21E7F365224444EA00270330 /* Heap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Heap.h; sourceTree = "<group>"; };
 		4DE526A81ECD4A340059312E /* RNHeap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNHeap.h; sourceTree = "<group>"; };
 		4DE526A91ECD4A340059312E /* RNHeap.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNHeap.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -33,6 +24,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				21C146AB224AEB1500764BE4 /* libHeap.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -44,7 +36,9 @@
 			children = (
 				4DE526A81ECD4A340059312E /* RNHeap.h */,
 				4DE526A91ECD4A340059312E /* RNHeap.m */,
+				21E7F5372249537B00270330 /* Vendor */,
 				112EE36E1CC0AB8A00BF6BB8 /* Products */,
+				21C146AA224AEB1500764BE4 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -56,6 +50,22 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		21C146AA224AEB1500764BE4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		21E7F5372249537B00270330 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				21E7F365224444EA00270330 /* Heap.h */,
+				21E7F364224444E700270330 /* libHeap.a */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -65,7 +75,6 @@
 			buildPhases = (
 				112EE3691CC0AB8A00BF6BB8 /* Sources */,
 				112EE36A1CC0AB8A00BF6BB8 /* Frameworks */,
-				112EE36B1CC0AB8A00BF6BB8 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -83,7 +92,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0800;
-				ORGANIZATIONNAME = "Heap";
+				ORGANIZATIONNAME = Heap;
 				TargetAttributes = {
 					112EE36C1CC0AB8A00BF6BB8 = {
 						CreatedOnToolsVersion = 7.3;
@@ -95,6 +104,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 112EE3641CC0AB8A00BF6BB8;
@@ -216,9 +226,15 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/Vendor",
 					"$(SRCROOT)/../react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Vendor",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -237,9 +253,15 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/Vendor",
 					"$(SRCROOT)/../react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Vendor",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/Vendor/Heap.h
+++ b/ios/Vendor/Heap.h
@@ -1,0 +1,182 @@
+//
+//  Heap.h
+//  Version 5.1.0
+//  Copyright (c) 2014 Heap Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+// Makes nonnull annotation default everywhere. We can explicitly annotate with
+// nullable if necessary. This makes Swift use non-optional types instead of
+// implicitly unwrapped optionals.
+NS_ASSUME_NONNULL_BEGIN
+
+/// @name Heap library
+
+/// The Heap API.
+@interface Heap : NSObject
+
+/// @name Developer methods
+
+/// Return the version number of the Heap library.
++ (NSString * const)libVersion;
+
+/**
+ * Set the app ID for your project, and begin tracking events automatically.
+ *
+ * @param newAppId       the Heap app ID
+ */
++ (void)setAppId:(NSString *)newAppId;
+
+/**
+ * Enable the Event Visualizer to allow defining events in Heap.
+ *
+ * This should not be called in the release version of an app.
+ *
+ * @see [Event visualizer for iOS apps](https://heapanalytics.com/docs/define-events#visualizer-for-ios-apps)
+ */
++ (void)enableVisualizer;
+
+/**
+ * Start debug logging of Heap activity via NSLog.
+ *
+ * This should not be called in the release version of an app.
+ */
++ (void)startDebug;
+
+/**
+ * Stop debug logging.
+ */
++ (void)stopDebug;
+
+/**
+ * Change the frequency at which data is sent to Heap.
+ *
+ * The default is 15 seconds. A shorter interval may result in increased power
+ * consumption.
+ *
+ * @param interval     number of seconds between pushing events to Heap
+ */
++ (void)changeInterval:(double)interval;
+
+
+/// @name User identities and properties
+
+/// Return the Heap-generated user ID of the current user.
++ (NSString * const)userId;
+
+/**
+ * Attach a unique identifier to a user.
+ *
+ * If you assign the same identity to a user on a separate device, their past
+ * sessions and event activity will be merged into the existing Heap user with
+ * that identity.
+ *
+ * The identity must be no longer than 255 characters.
+ *
+ * @param identity     case-sensitive string that uniquely identifies a user
+ *
+ * @see addUserProperties:
+ * @see [User identities and properties](https://heapanalytics.com/docs/using-identify)
+ */
++ (void)identify:(NSString *)identity;
+
+/**
+ * Attach custom properties to user profiles.
+ *
+ * User properties are associated with all of the user's past activity, in
+ * addition to their future activity. Custom user properties can be queried in the
+ * same fashion as any other user property.
+ *
+ * Examples include account-level info from your database, A/B test data, or
+ * demographic info.
+ *
+ * Keys and values must be a numbers or strings with fewer than 1024 characters.
+ * The string user_id cannot be used as a key in the user properties object.
+ *
+ * @param properties    key-value pairs to be associated with a user
+ *
+ * @see identify:
+ * @see [User identities and properties](https://heapanalytics.com/docs/using-identify)
+ */
++ (void)addUserProperties:(NSDictionary *)properties;
+
+
+/// @name Custom events
+
+/**
+ * Track a custom event.
+ *
+ * The event name is limited to 1024 characters.
+ *
+ * @param event        the event name
+ *
+ * @see track:withProperties:
+ * @see [track in Heap documentation](https://heapanalytics.com/docs/custom-api#track)
+ */
++ (void)track:(NSString *)event;
+
+/**
+ * Track a custom event with properties.
+ *
+ * The event name is limited to 1024 characters. Keys and values must be a
+ * numbers or strings with fewer than 1024 characters.
+ *
+ * @param event        the event name
+ * @param properties   key-value pairs to associate with the event
+ *
+ * @see track:
+ * @see [track in Heap documentation](https://heapanalytics.com/docs/custom-api#track)
+ */
++ (void)track:(NSString *)event withProperties:(nullable NSDictionary *)properties;
+
+
+/// @name Global event properties
+
+/**
+ * Specify global key-value pairs to attach to all of a user's subsequent events.
+ *
+ * These event properties will persist across multiple sessions on the same
+ * device and get applied to both auto-captured and custom events. This is
+ * useful if you have some persistent state, but you don't want to apply it
+ * across all of a user's events with identify.
+ *
+ * A good example is "Logged In", which changes over the user's lifecycle. You
+ * can use addEventProperties to measure how a user's behavior changes when
+ * they're logged in vs. when they're logged out.
+ *
+ * @param properties   key-value pairs to associate with future events
+ *
+ * @see removeEventProperty:
+ * @see clearEventProperties
+ */
++ (void)addEventProperties:(NSDictionary *)properties;
+/**
+ * Stops a single event property from getting attached to all subsequent events.
+ *
+ * @param property     the name of the property remove
+ *
+ * @see addEventProperties:
+ * @see clearEventProperties
+ */
++ (void)removeEventProperty:(NSString *)property;
+
+/**
+ * Remove all properties added with addEventProperties:.
+ *
+ * @see addEventProperties:
+ * @see removeEventProperty:
+ */
++ (void)clearEventProperties;
+
+
+/// @name Deprecated methods
+
+/// Alias for addEventProperties:.
++ (void)setEventProperties:(NSDictionary *)properties __deprecated_msg("Use addEventProperties instead");
+/// Alias for removeEventProperty:.
++ (void)unsetEventProperty:(NSString *)property __deprecated_msg("Use removeEventProperty instead");
+
+@end
+NS_ASSUME_NONNULL_END

--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -11,9 +11,10 @@ Pod::Spec.new do |s|
   s.author = package[:author]
   s.homepage = package[:homepage]
   s.source = { git: package[:repository] }
-  s.source_files = "ios/*"
+  s.source_files = "ios/**/*.{h,m}"
   s.platform = :ios, "8.0"
+  s.preserve_paths = "ios/Vendor"
+  s.vendored_libraries = "ios/Vendor/libHeap.a"
 
   s.dependency "React"
-  s.dependency "Heap", "5.1.0"
 end


### PR DESCRIPTION
Currently, the binary lib gets pulled down from Cocoapods, but this makes it difficult to do a manual integration if you're allergic to Cocoapods.  This change makes it so that the binary is included, and rejiggers the podspec to link the binary directly.

Tested manually, both with Cocoapods and a manual linking setup.