### PR TITLE
android: use parent project's version information if available

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    api "com.heapanalytics.android:heap-android-client:0.8.3"
+    api 'com.heapanalytics.android:heap-android-client:0.8.3'
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,7 @@ android {
     compileSdkVersion safeExtGet('compileSdkVersion', 26)
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
+        minSdkVersion 16
         targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,14 +9,18 @@ buildscript {
     }
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
     }
@@ -31,6 +35,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
-    api 'com.heapanalytics.android:heap-android-client:0.8.3'
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    api "com.heapanalytics.android:heap-android-client:0.8.3"
 }
+


### PR DESCRIPTION
Fixes issue where parent project on a different sdkVersion wouldn't be able to build this library