### PR TITLE
Get Android TestDriver working with new Detox version.

### DIFF
--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -109,7 +109,7 @@ android {
         }
         testBuildType System.getProperty('testBuildType', 'debug')  //this will later be used to control the test apk build type
         missingDimensionStrategy "minReactNative", "minReactNative46" //read note
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     splits {
         abi {
@@ -153,8 +153,6 @@ dependencies {
     implementation project(':@heap_react-native-heap')
     androidTestImplementation(project(path: ":detox"))
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.1'
-    androidTestImplementation 'com.android.support.test:rules:1.0.1'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/examples/TestDriver/android/build.gradle
+++ b/examples/TestDriver/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         targetSdkVersion = 26
         supportLibVersion = "27.1.1"
         ext.heapVersion = '0.7.4'
+        ext.kotlinVersion = '1.3.0'
     }
     repositories {
         google()
@@ -16,6 +17,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath "com.heapanalytics.android:heap-android-gradle:${heapVersion}"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Detox was upgraded in #64; this transition caused breaking changes in
the Android TestDriver app which weren't addressed. This change gets
the Android build working again.

https://heap.slack.com/archives/CFB8RN9A9/p1553899644006100