### PR TITLE
Use `Navigate/INITIAL` for the initial react-navigation action.

### DIFF
--- a/e2e/00_initial.spec.js
+++ b/e2e/00_initial.spec.js
@@ -17,6 +17,6 @@ describe('Initial Navigation', () => {
   });
 
   it('tracks the initial route', async () => {
-    await rnTestUtil.assertNavigationEvent('Initial');
+    await rnTestUtil.assertNavigationEvent('Initial', 'Heap_Navigation/INITIAL');
   });
 });

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -2,6 +2,11 @@ import React from 'react';
 
 const EVENT_TYPE = 'reactNavigationScreenview';
 
+// `react-native-navigation` uses `Navigation/{NAVIGATE,POP,BACK}` to represent
+// different types of navigation actions. We build the initial navigation action
+// ourselves, so we invent a fourth navigation type to represent this action.
+const INITIAL_ROUTE_TYPE = 'Heap_Navigation/INITIAL';
+
 export const withReactNavigationAutotrack = track => AppContainer => {
   return class HeapNavigationWrapper extends React.Component {
     topLevelNavigator = null;
@@ -13,6 +18,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
 
       track(EVENT_TYPE, {
         path: initialPageviewPath,
+        type: INITIAL_ROUTE_TYPE,
       });
     }
 


### PR DESCRIPTION
- React navigation uses one of `Navigate/{NAVIGATE,BACK,POP}` to
represent various navigation-related actions. We capture these in the
`type` custom prop when intercepting these actions in
`onNavigationStateChange`.

- We create the initial navigation action that fires when the app is
loaded, and this was not assigned an action type so far, which makes the
event more difficult to distinguish.

- This commit picks `Navigate/INITIAL` as the identifier for this
initial navigation event.

- The event ends up looking like this in Kafka:

```json
{
  "meta": {
    "isFullEvent": true,
    "received_at": "1554802335285"
  },
  "type": "event",
  "body": {
    "pageview_id": "8638062634366642",
    "session_id": "1448579568939958",
    "user_id": "3430884887124024",
    "app_id": "11",
    "library": "ios",
    "type": "reactNavigationScreenview",
    "time": "1554802322871",
    "view_controller": "UIViewController",
    "pageview_time": "1554801819421",
    "app_name": "TestDriver",
    "app_version": "1.0",
    "platform": "iOS 12.2",
    "phone_model": "Simulator",
    "device_type": "Mobile",
    "ip": "::1",
    "session_time": "1554801765273",
    "event_id": "8743158339869562"
  },
  "custom": {
    "path": "Initial",
    "type": "Heap_Navigate/INITIAL",
    "hb": "0"
  }
}
```

- https://heapeng.atlassian.net/browse/HEAP-8480