### PR TITLE
[HEAP-8473] Capture the `key` property for list items that have it set.

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -225,7 +225,7 @@ describe('Basic React Native and Touchable Support', () => {
   describe('Autotrack', () => {
     it("should autotrack 'TouchableOpacity's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableOpacity;[testID=touchableOpacityText];|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableOpacity;[testID=touchableOpacityText];|';
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -236,7 +236,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableHighlight's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableHighlight;[testID=touchableHighlightText];|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableHighlight;[testID=touchableHighlightText];|';
       const expectedTargetText = 'Touchable Highlight';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -247,7 +247,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|';
       const expectedTargetText = 'Touchable Without Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',
@@ -258,7 +258,7 @@ describe('Basic React Native and Touchable Support', () => {
 
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
       const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|';
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|';
       const expectedTargetText = 'Touchable Native Feedback';
       await rnTestUtil.assertAutotrackHierarchy(
         'touchableHandlePress',

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -41,7 +41,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with class components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[testID=button1];[title=testButtonTitle1];|${buttonSuffix}[testID=button1];|`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[testID=button1];[title=testButtonTitle1];|${buttonSuffix}[testID=button1];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle1'
@@ -54,7 +54,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with stateless components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[testID=button2];[title=testButtonTitle2];|${buttonSuffix}[testID=button2];|`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[testID=button2];[title=testButtonTitle2];|${buttonSuffix}[testID=button2];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle2'
@@ -69,7 +69,7 @@ describe('Property Extraction in Hierarchies', () => {
     it('properly excludes properties', async () => {
       // The important thing for this test is that the first mention of 'Button' does NOT include the title property.
       // This is because the first one is a custom class that specifically excludes (while the second one is the built-in Button.)
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;|SceneView;|PropExtraction;|Button;|Button;[testID=button3];[title=testButtonTitle3];|${buttonSuffix}[testID=button3];|`;
+      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|Button;|Button;[testID=button3];[title=testButtonTitle3];|${buttonSuffix}[testID=button3];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle3'

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -15,6 +15,7 @@ export interface FiberNode {
     [propertyKey: string]: any;
   };
   stateNode?: StateNode;
+  key?: any;
   type?: {
     heapOptions?: ClassHeapOptions;
   };
@@ -87,7 +88,14 @@ export const extractProps = (
   }
 
   const filteredProps = _.pick(props, inclusionList);
-  const flattenedProps = flatten(filteredProps);
+
+  // KLUDGE: We want to capture the `key` property for list components that have it set,
+  // but we can't simply add to the list of props captured for all components in
+  // `propExtractorConfig` because `props.key` is always undefined and guarded with
+  // a yellowbox warning; this is to prevent client code from appropriating the `key`
+  // prop for its own use; it is intended to be reserved for internal use. (HEAP-8473)
+  const flattenedProps = Object.assign({ key: fiberNode.key }, flatten(filteredProps));
+
   let propsString = '';
 
   // Only include props that are primitives.


### PR DESCRIPTION
- We have to special-case this a bit because React doesn't allow access to
the `key` property without a yellowbox warning popping up.

- e2e tests are passing locally.

https://reactjs.org/docs/lists-and-keys.html