### PR TITLE
Autotrack for RN Switch components

### DIFF
--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -146,6 +146,7 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-gesture-handler')
     implementation project(':react-native-gesture-handler')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"

--- a/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
+++ b/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 
 import com.facebook.react.ReactApplication;
 import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
+import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
 import com.heapanalytics.android.internal.HeapImpl;
 import com.heapanalytics.reactnative.RNHeapLibraryPackage;
 import com.facebook.react.ReactNativeHost;
@@ -26,6 +27,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
         new MainReactPackage(),
+            new RNGestureHandlerPackage(),
         new RNGestureHandlerPackage(),
         new RNHeapLibraryPackage()
       );

--- a/examples/TestDriver/android/settings.gradle
+++ b/examples/TestDriver/android/settings.gradle
@@ -1,6 +1,8 @@
 rootProject.name = 'TestDriver'
 include ':react-native-gesture-handler'
 project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
+include ':react-native-gesture-handler'
+project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
 include ':@heap_react-native-heap'
 project(':@heap_react-native-heap').projectDir = new File(rootProject.projectDir, '../node_modules/@heap/react-native-heap/android')
 

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -105,11 +105,11 @@ SPEC CHECKSUMS:
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
   glog: e8acf0ebbf99759d3ff18c86c292a5898282dcde
-  React: 01aa04500b2957c2767e1dff9fe12e09444a467c
-  react-native-heap: e75c689169e157e25a236be2c072bf24aa195824
-  RNGestureHandler: b65d391f4f570178d657b99a16ec99d09b8656b0
-  yoga: a5c0ba30ebe82c13612b4c9301ad29708b8978dc
+  React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
+  react-native-heap: 381fd78115a2a1314dae2906b893221c9501d12d
+  RNGestureHandler: afde2addc517e85cc97a25bfe119acbee779a7ce
+  yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
 
 PODFILE CHECKSUM: 94963ca9da08a6f38a9019eb8da64ec0f890b712
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.5.3

--- a/examples/TestDriver/ios/TestDriver.xcodeproj/project.pbxproj
+++ b/examples/TestDriver/ios/TestDriver.xcodeproj/project.pbxproj
@@ -393,7 +393,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh",
+				"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/DoubleConversion/DoubleConversion.framework",
 				"${BUILT_PRODUCTS_DIR}/Folly/folly.framework",
 				"${BUILT_PRODUCTS_DIR}/RNGestureHandler/RNGestureHandler.framework",
@@ -414,7 +414,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E5F03DDBB7275D0F8105EA52 /* [CP] Check Pods Manifest.lock */ = {

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@heap/react-native-heap": "heap-react-native-heap-0.2.0.tgz",
+    "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",
     "react-native-gesture-handler": "^1.1.0",

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -11,6 +11,7 @@
     "@heap/react-native-heap": "heap-react-native-heap-0.2.0.tgz",
     "react": "16.6.1",
     "react-native": "0.57.5",
+    "react-native-gesture-handler": "^1.1.0",
     "react-navigation": "^3.3.2",
     "react-redux": "^5.1.1",
     "redux": "^4.0.1"

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -3,6 +3,7 @@ import {
   Button,
   Platform,
   StyleSheet,
+  Switch,
   Text,
   TouchableHighlight,
   TouchableNativeFeedback,
@@ -10,7 +11,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
-import { Switch } from 'native-base';
+import { Switch as NbSwitch } from 'native-base';
 import { connect } from 'react-redux';
 
 import Heap from '@heap/react-native-heap';
@@ -21,6 +22,7 @@ class BasicsPage extends Component {
   render() {
     return (
       <View style={styles.container}>
+        <NbSwitch testID="switch" onValueChange={() => console.log('stuff')} />
         <Switch testID="switch" onValueChange={() => console.log('stuff')} />
         <Button
           testID="track1"

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -10,6 +10,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
+import { Switch } from 'native-base';
 import { connect } from 'react-redux';
 
 import Heap from '@heap/react-native-heap';
@@ -20,6 +21,7 @@ class BasicsPage extends Component {
   render() {
     return (
       <View style={styles.container}>
+        <Switch testID="switch" onValueChange={() => console.log('stuff')}/>
         <Button
           testID="track1"
           title="Call Track1"

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -21,7 +21,7 @@ class BasicsPage extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <Switch testID="switch" onValueChange={() => console.log('stuff')}/>
+        <Switch testID="switch" onValueChange={() => console.log('stuff')} />
         <Button
           testID="track1"
           title="Call Track1"

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -3,6 +3,11 @@
 const t = require('babel-types');
 const template = require('babel-template');
 
+// Used to record whether certain methods/components have been instrumented.
+// :TODO: (jmtaber129): Determine whether we actually need this once we figure out the unexpected
+// behavior with the instrumented Switch node being visited multiple times.
+const instrumentationMap = new Set();
+
 const buildFunctionWrapper = template(`{
   const Heap = require('@heap/react-native-heap').default;
 
@@ -57,39 +62,127 @@ const instrumentTouchables = path => {
     // Create the expression for calling the original function for this listener.
     // '(<original function>).call(this, e)'.
     const originalFunctionExpression = path.node.value;
-    const callOriginalFunctionExpression = t.memberExpression(
-      originalFunctionExpression,
-      t.identifier('call')
-    );
-    const calledFunction = t.callExpression(callOriginalFunctionExpression, [
-      t.identifier('this'),
-      t.identifier('e'),
-    ]);
 
-    // Create the expression for calling Heap autotrack. Pass 'this' so we have the component
-    // context to extract the hierarchy, and 'e' so we have context on the event.
-    // 'Heap.autotrackPress(<press type>, this, e)'.
-    const autotrackExpression = t.callExpression(
-      t.memberExpression(t.identifier('Heap'), t.identifier('autotrackPress')),
-      [
-        t.stringLiteral(path.node.key.name),
-        t.identifier('this'),
-        t.identifier('e'),
-      ]
-    );
-
-    // Function body for tracking the Heap event, then calling the original function.
-    const functionBody = buildFunctionWrapper({
-      AUTOTRACK_EXPRESSION: autotrackExpression,
-      ORIGINAL_FUNCTION_CALL: calledFunction,
-    });
-
-    // Call the function body with the event parameter 'e'.
-    const replacementFunc = t.arrowFunctionExpression(
-      [t.identifier('e')],
-      functionBody
+    const replacementFunc = getOriginalFunctionReplacement(
+      /*originalFunctionExpression=*/ path.node.value,
+      /*thisContext=*/ 'this',
+      /*heapMethodName=*/ 'autotrackPress',
+      /*trackedMethodName=*/ path.node.key.name
     );
     path.get('value').replaceWith(replacementFunc);
+  }
+};
+
+const getOriginalFunctionReplacement = (
+  originalFunctionExpression,
+  thisIdentifier,
+  autotrackMethodName,
+  eventType
+) => {
+  const callOriginalFunctionExpression = t.memberExpression(
+    originalFunctionExpression,
+    t.identifier('call')
+  );
+
+  const calledFunction = t.callExpression(callOriginalFunctionExpression, [
+    t.identifier(thisIdentifier),
+    t.identifier('e'),
+  ]);
+
+  // Create the expression for calling Heap autotrack. Pass 'this' so we have the component
+  // context to extract the hierarchy, and 'e' so we have context on the event.
+  // 'Heap.autotrackPress(<press type>, this, e)'.
+  const autotrackExpression = t.callExpression(
+    t.memberExpression(t.identifier('Heap'), t.identifier(autotrackMethodName)),
+    [
+      t.stringLiteral(eventType),
+      t.identifier(thisIdentifier),
+      t.identifier('e'),
+    ]
+  );
+
+  // Function body for tracking the Heap event, then calling the original function.
+  const functionBody = buildFunctionWrapper({
+    AUTOTRACK_EXPRESSION: autotrackExpression,
+    ORIGINAL_FUNCTION_CALL: calledFunction,
+  });
+
+  // Call the function body with the event parameter 'e'.
+  return t.arrowFunctionExpression([t.identifier('e')], functionBody);
+};
+
+const extendsReactComponent = path => {
+  // By the time we start traversing the AST for Switch.js, the 'Switch' class looks like:
+  //
+  //   var Switch = function (_React$Component) {
+  //     (0, _inherits2.default)(Switch, _React$Component);
+  //
+  //     function Switch() {
+  //       <class body>
+  //     }
+  //
+  //     return Switch;
+  //   }(React.Component);
+  //
+  // so to determine whether this extends 'React.Component', we should check the argument to the
+  // function on the RHS of the variable declarator node for 'React.Component' or 'Component'.
+  // :TODO: (jmtaber129): Consider adding a check for the line that looks like:
+  //   (0, _inherits2.default)(Switch, _React$Component)
+  const reactComponentCandidate =
+    path.node.init && path.node.init.arguments && path.node.init.arguments[0];
+  return (
+    reactComponentCandidate &&
+    ((reactComponentCandidate.object &&
+      reactComponentCandidate.object.name === 'React' &&
+      reactComponentCandidate.property &&
+      reactComponentCandidate.property.name === 'Component') ||
+      reactComponentCandidate.name === 'Component')
+  );
+};
+
+const instrumentSwitch = path => {
+  if (instrumentationMap.has('switch')) {
+    // We already instrumented the switch, so do nothing.
+    return;
+  }
+
+  // The method we want to instrument:
+  // * Is named '_handleChange'
+  // * Has a variable declarator parent named 'Switch'
+  // * Extends 'React.Component'.
+  if (
+    path.node.left.property &&
+    path.node.left.property.name === '_handleChange'
+  ) {
+    const parent = path.findParent(path => {
+      return (
+        path.isVariableDeclarator() &&
+        path.node.id.name === 'Switch' &&
+        extendsReactComponent(path)
+      );
+    });
+
+    if (!parent) {
+      return;
+    }
+
+    // Create the expression for calling the original function for this listener.
+    // '(<original function>).call(this, e)'.
+    const originalFunctionExpression = path.node.right;
+    const replacementFunc = getOriginalFunctionReplacement(
+      originalFunctionExpression,
+      '_this',
+      'autotrackSwitchChange',
+      path.node.left.property.name
+    );
+
+    path.get('right').replaceWith(replacementFunc);
+
+    // :KLUDGE: There's some unexpected behavior in the babel traverser that seems to cause the AST
+    // node we're instrumenting to be visited multiple times. To avoid unintentionally wrapping the
+    // same method multiple times, record that we've instrumented the switch.
+    // :TODO: (jmtabe129): Remove this once we figure out what's going on here.
+    instrumentationMap.add('switch');
   }
 };
 
@@ -132,6 +225,9 @@ function transform(babel) {
       ObjectProperty(path) {
         instrumentStartup(path);
         instrumentTouchables(path);
+      },
+      AssignmentExpression(path) {
+        instrumentSwitch(path, babel);
       },
     },
   };

--- a/instrumentor/test/fixtures/is-switch/code.js
+++ b/instrumentor/test/fixtures/is-switch/code.js
@@ -1,0 +1,25 @@
+'use strict';
+
+class Switch extends React.Component<Props> {
+  _handleChange = (event: SwitchChangeEvent) => {
+    if (this._nativeSwitchRef == null) {
+      return;
+    }
+
+    // Force value of native switch in order to control it.
+    const value = this.props.value === true;
+    if (Platform.OS === 'android') {
+      this._nativeSwitchRef.setNativeProps({on: value});
+    } else {
+      this._nativeSwitchRef.setNativeProps({value});
+    }
+
+    if (this.props.onChange != null) {
+      this.props.onChange(event);
+    }
+
+    if (this.props.onValueChange != null) {
+      this.props.onValueChange(event.nativeEvent.value);
+    }
+  };
+}

--- a/instrumentor/test/fixtures/is-switch/output.js
+++ b/instrumentor/test/fixtures/is-switch/output.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
+
+var _possibleConstructorReturn2 = _interopRequireDefault(require("@babel/runtime/helpers/possibleConstructorReturn"));
+
+var _getPrototypeOf3 = _interopRequireDefault(require("@babel/runtime/helpers/getPrototypeOf"));
+
+var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
+
+var Switch = function (_React$Component) {
+  (0, _inherits2.default)(Switch, _React$Component);
+
+  function Switch() {
+    var _getPrototypeOf2;
+
+    var _this;
+
+    (0, _classCallCheck2.default)(this, Switch);
+
+    for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
+    }
+
+    _this = (0, _possibleConstructorReturn2.default)(this, (_getPrototypeOf2 = (0, _getPrototypeOf3.default)(Switch)).call.apply(_getPrototypeOf2, [this].concat(args)));
+
+    _this._handleChange = function (e) {
+      var Heap = require('@heap/react-native-heap').default;
+
+      Heap.autotrackSwitchChange("_handleChange", _this, e);
+      (function (event) {
+        if (_this._nativeSwitchRef == null) {
+          return;
+        }
+
+        var value = _this.props.value === true;
+
+        if (Platform.OS === 'android') {
+          _this._nativeSwitchRef.setNativeProps({
+            on: value
+          });
+        } else {
+          _this._nativeSwitchRef.setNativeProps({
+            value: value
+          });
+        }
+
+        if (_this.props.onChange != null) {
+          _this.props.onChange(event);
+        }
+
+        if (_this.props.onValueChange != null) {
+          _this.props.onValueChange(event.nativeEvent.value);
+        }
+      }).call(_this, e);
+    };
+
+    return _this;
+  }
+
+  return Switch;
+}(React.Component);

--- a/instrumentor/test/index.js
+++ b/instrumentor/test/index.js
@@ -35,6 +35,12 @@ describe('autotrack instrumentor plugin', () => {
     var expected = getExpectedTransformedFile('run-application');
     assert.equal(actual, expected);
   });
+
+  it('switch should be instrumented', () => {
+    var actual = getActualTransformedFile('is-switch');
+    var expected = getExpectedTransformedFile('is-switch');
+    assert.equal(actual, expected);
+  })
 });
 
 const getActualTransformedFile = fixtureName => {

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { NativeModules } from 'react-native';
 
 import { autotrackPress } from './autotrack/touchables';
+import { autotrackSwitchChange } from './autotrack/switches';
 import { checkDisplayNamePlugin } from './util/checkDisplayNames';
 import { withReactNavigationAutotrack } from './autotrack/reactNavigation';
 
@@ -49,5 +50,6 @@ export default {
   },
 
   autotrackPress: autotrackPress(track),
+  autotrackSwitchChange: autotrackSwitchChange(track),
   withReactNavigationAutotrack: withReactNavigationAutotrack(track),
 };

--- a/js/autotrack/common.js
+++ b/js/autotrack/common.js
@@ -1,0 +1,87 @@
+import { extractProps } from '../util/extractProps';
+import { builtinPropExtractorConfig } from '../propExtractorConfig';
+
+export const getBaseComponentProps = componentThis => {
+  const touchableHierarchy = getComponentHierarchy(componentThis);
+
+  const targetText = getTargetText(componentThis._reactInternalFiber);
+
+  const autotrackProps = {
+    touchableHierarchy,
+  };
+
+  if (targetText !== '') {
+    autotrackProps.targetText = targetText;
+  }
+
+  return autotrackProps;
+}
+
+const getComponentHierarchy = componentThis => {
+  // :TODO: (jmtaber129): Remove this if/when we support pre-fiber React.
+  if (!componentThis._reactInternalFiber) {
+    throw new Error(
+      'Pre-fiber React versions (React 16) are currently not supported by Heap autotrack.'
+    );
+  }
+
+  return getFiberNodeComponentHierarchy(componentThis._reactInternalFiber);
+};
+
+const getFiberNodeComponentHierarchy = currNode => {
+  if (currNode === null) {
+    return '';
+  }
+
+  // Skip components we don't care about.
+  // :TODO: (jmtaber129): Skip components with names/display names like 'View' and '_class'.
+  if (
+    currNode.type === 'RCTView' ||
+    currNode.type === null ||
+    !(currNode.type.displayName || currNode.type.name)
+  ) {
+    return getFiberNodeComponentHierarchy(currNode.return);
+  }
+
+  const elementName = currNode.type.displayName || currNode.type.name;
+
+  // In dev builds, 'View' components remain in the fiber tree, but don't provide any useful
+  // information, so exclude these from the hierarchy.
+  if (elementName === 'View') {
+    return getFiberNodeComponentHierarchy(currNode.return);
+  }
+
+  const propsString = extractProps(
+    elementName,
+    currNode,
+    builtinPropExtractorConfig
+  );
+
+  return `${getFiberNodeComponentHierarchy(
+    currNode.return
+  )}${elementName};${propsString}|`;
+};
+
+// :TODO: (jmtaber129): Consider implementing sibling target text.
+const getTargetText = fiberNode => {
+  if (fiberNode.type === 'RCTText') {
+    return fiberNode.memoizedProps.children;
+  }
+
+  if (fiberNode.child === null) {
+    return '';
+  }
+
+  const children = [];
+  let currChild = fiberNode.child;
+  while (currChild) {
+    children.push(currChild);
+    currChild = currChild.sibling;
+  }
+
+  let targetText = '';
+  children.forEach(child => {
+    targetText = (targetText + ' ' + getTargetText(child)).trim();
+  });
+  return targetText;
+};

--- a/js/autotrack/common.js
+++ b/js/autotrack/common.js
@@ -15,7 +15,7 @@ export const getBaseComponentProps = componentThis => {
   }
 
   return autotrackProps;
-}
+};
 
 const getComponentHierarchy = componentThis => {
   // :TODO: (jmtaber129): Remove this if/when we support pre-fiber React.

--- a/js/autotrack/switches.js
+++ b/js/autotrack/switches.js
@@ -1,0 +1,7 @@
+import { getBaseComponentProps } from './common';
+
+export const autotrackSwitchChange = track => (eventType, componentThis, event) => {
+  const autotrackProps = getBaseComponentProps(componentThis);
+
+  track(eventType, autotrackProps);
+};

--- a/js/autotrack/switches.js
+++ b/js/autotrack/switches.js
@@ -1,6 +1,10 @@
 import { getBaseComponentProps } from './common';
 
-export const autotrackSwitchChange = track => (eventType, componentThis, event) => {
+export const autotrackSwitchChange = track => (
+  eventType,
+  componentThis,
+  event
+) => {
   const autotrackProps = getBaseComponentProps(componentThis);
 
   track(eventType, autotrackProps);

--- a/js/autotrack/touchables.js
+++ b/js/autotrack/touchables.js
@@ -1,93 +1,13 @@
-import { extractProps } from '../util/extractProps';
-import { builtinPropExtractorConfig } from '../propExtractorConfig';
+import { getBaseComponentProps } from './common';
 
 export const autotrackPress = track => (eventType, componentThis, event) => {
-  const touchableHierarchy = getComponentHierarchy(componentThis);
   const touchState =
     componentThis &&
     componentThis.state &&
     componentThis.state.touchable &&
     componentThis.state.touchable.touchState;
 
-  const targetText = getTargetText(componentThis._reactInternalFiber);
-
-  const autotrackProps = {
-    touchableHierarchy,
-    touchState,
-  };
-
-  if (targetText !== '') {
-    autotrackProps.targetText = targetText;
-  }
+  const autotrackProps = {...getBaseComponentProps(componentThis), touchState};
 
   track(eventType, autotrackProps);
-};
-
-const getComponentHierarchy = componentThis => {
-  // :TODO: (jmtaber129): Remove this if/when we support pre-fiber React.
-  if (!componentThis._reactInternalFiber) {
-    throw new Error(
-      'Pre-fiber React versions (React 16) are currently not supported by Heap autotrack.'
-    );
-  }
-
-  return getFiberNodeComponentHierarchy(componentThis._reactInternalFiber);
-};
-
-const getFiberNodeComponentHierarchy = currNode => {
-  if (currNode === null) {
-    return '';
-  }
-
-  // Skip components we don't care about.
-  // :TODO: (jmtaber129): Skip components with names/display names like 'View' and '_class'.
-  if (
-    currNode.type === 'RCTView' ||
-    currNode.type === null ||
-    !(currNode.type.displayName || currNode.type.name)
-  ) {
-    return getFiberNodeComponentHierarchy(currNode.return);
-  }
-
-  const elementName = currNode.type.displayName || currNode.type.name;
-
-  // In dev builds, 'View' components remain in the fiber tree, but don't provide any useful
-  // information, so exclude these from the hierarchy.
-  if (elementName === 'View') {
-    return getFiberNodeComponentHierarchy(currNode.return);
-  }
-
-  const propsString = extractProps(
-    elementName,
-    currNode,
-    builtinPropExtractorConfig
-  );
-
-  return `${getFiberNodeComponentHierarchy(
-    currNode.return
-  )}${elementName};${propsString}|`;
-};
-
-// :TODO: (jmtaber129): Consider implementing sibling target text.
-const getTargetText = fiberNode => {
-  if (fiberNode.type === 'RCTText') {
-    return fiberNode.memoizedProps.children;
-  }
-
-  if (fiberNode.child === null) {
-    return '';
-  }
-
-  const children = [];
-  let currChild = fiberNode.child;
-  while (currChild) {
-    children.push(currChild);
-    currChild = currChild.sibling;
-  }
-
-  let targetText = '';
-  children.forEach(child => {
-    targetText = (targetText + ' ' + getTargetText(child)).trim();
-  });
-  return targetText;
 };

--- a/js/autotrack/touchables.js
+++ b/js/autotrack/touchables.js
@@ -7,7 +7,10 @@ export const autotrackPress = track => (eventType, componentThis, event) => {
     componentThis.state.touchable &&
     componentThis.state.touchable.touchState;
 
-  const autotrackProps = {...getBaseComponentProps(componentThis), touchState};
+  const autotrackProps = {
+    ...getBaseComponentProps(componentThis),
+    touchState,
+  };
 
   track(eventType, autotrackProps);
 };


### PR DESCRIPTION
Autotrack when a `Switch` is toggled.

This covers both the NativeBase and React Native `Switch` components (NativeBase delegates to the RN `Switch).

This PR includes a refactor of the `autotrack` folder, in which logic used by autotrack methods for both `Switch`es and `Touchable`s was pulled into a separate `common.js` file.

~e2e tests are in progress and will likely be pushed up later today or early-ish tomorrow.~

Will open e2e tests in a separate PR, since these depend on a separate test util refactor.