### PR TITLE
Refactor RN test utils to accept generic props

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -228,43 +228,41 @@ describe('Basic React Native and Touchable Support', () => {
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableOpacity;[testID=touchableOpacityText];|';
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy(
-        'touchableHandlePress',
-        expectedHierarchy,
-        expectedTargetText
-      );
+      'touchableHandlePress',
+        {
+          touchableHierarchy: expectedHierarchy,
+          targetText: expectedTargetText,
+        });
     });
 
     it("should autotrack 'TouchableHighlight's", async () => {
       const expectedHierarchy =
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableHighlight;[testID=touchableHighlightText];|';
       const expectedTargetText = 'Touchable Highlight';
-      await rnTestUtil.assertAutotrackHierarchy(
-        'touchableHandlePress',
-        expectedHierarchy,
-        expectedTargetText
-      );
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        touchableHierarchy: expectedHierarchy,
+        targetText: expectedTargetText,
+      });
     });
 
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
       const expectedHierarchy =
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|';
       const expectedTargetText = 'Touchable Without Feedback';
-      await rnTestUtil.assertAutotrackHierarchy(
-        'touchableHandlePress',
-        expectedHierarchy,
-        expectedTargetText
-      );
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        touchableHierarchy: expectedHierarchy,
+        targetText: expectedTargetText,
+      });
     });
 
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
       const expectedHierarchy =
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|';
       const expectedTargetText = 'Touchable Native Feedback';
-      await rnTestUtil.assertAutotrackHierarchy(
-        'touchableHandlePress',
-        expectedHierarchy,
-        expectedTargetText
-      );
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        touchableHierarchy: expectedHierarchy,
+        targetText: expectedTargetText,
+      });
     });
   });
 });

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -46,11 +46,10 @@ describe('Property Extraction in Hierarchies', () => {
         device.getPlatform() === 'ios'
           ? 'testButtonTitle1'
           : 'TESTBUTTONTITLE1';
-      await rnTestUtil.assertAutotrackHierarchy(
-        'touchableHandlePress',
-        expectedHierarchy,
-        expectedTargetText
-      );
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        touchableHierarchy: expectedHierarchy,
+        targetText: expectedTargetText,
+      });
     });
 
     it('works with stateless components', async () => {
@@ -59,11 +58,10 @@ describe('Property Extraction in Hierarchies', () => {
         device.getPlatform() === 'ios'
           ? 'testButtonTitle2'
           : 'TESTBUTTONTITLE2';
-      await rnTestUtil.assertAutotrackHierarchy(
-        'touchableHandlePress',
-        expectedHierarchy,
-        expectedTargetText
-      );
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        touchableHierarchy: expectedHierarchy,
+        targetText: expectedTargetText,
+      });
     });
 
     it('properly excludes properties', async () => {
@@ -74,11 +72,10 @@ describe('Property Extraction in Hierarchies', () => {
         device.getPlatform() === 'ios'
           ? 'testButtonTitle3'
           : 'TESTBUTTONTITLE3';
-      await rnTestUtil.assertAutotrackHierarchy(
-        'touchableHandlePress',
-        expectedHierarchy,
-        expectedTargetText
-      );
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        touchableHierarchy: expectedHierarchy,
+        targetText: expectedTargetText,
+      });
     });
   });
 });

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -1,4 +1,7 @@
 require('coffeescript').register();
+
+const _ = require('lodash');
+
 db = require('../../heap/back/db');
 testUtil = require('../../heap/test/util');
 
@@ -33,49 +36,30 @@ const assertAndroidEvent = async (event, check) => {
   assertEvent(err, res, check);
 };
 
-const assertAndroidAutotrackHierarchy = async (
-  expectedName,
-  expectedHierarchy,
-  expectedTargetText
-) => {
+const assertAndroidAutotrackHierarchy = async (expectedName, expectedProps) => {
   return assertAndroidEvent({
     envId: HEAP_ENV_ID,
     event: {
       custom: {
         name: expectedName,
-        properties: {
-          touchableHierarchy: {
-            string: expectedHierarchy,
-          },
-          targetText: {
-            string: expectedTargetText,
-          },
-        },
+        properties: _.mapValues(expectedProps, value => {
+          string: value;
+        }),
       },
     },
   });
 };
 
-const assertAutotrackHierarchy = async (
-  expectedName,
-  expectedHierarchy,
-  expectedTargetText
-) => {
+const assertAutotrackHierarchy = async (expectedName, expectedProps) => {
   if (device.getPlatform() === 'android') {
-    return assertAndroidAutotrackHierarchy(
-      expectedName,
-      expectedHierarchy,
-      expectedTargetText
-    );
+    return assertAndroidAutotrackHierarchy(expectedName, expectedProps);
   } else if (device.getPlatform() === 'ios') {
     return assertIosPixel({
       t: expectedName,
-      k: [
-        'touchableHierarchy',
-        expectedHierarchy,
-        'targetText',
-        expectedTargetText,
-      ],
+      k: _(expectedProps)
+        .map((value, key) => [key, value])
+        .flatten()
+        .value(),
     });
   } else {
     throw new Error(`Unknown device type: ${device.getPlatform()}`);

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -58,10 +58,7 @@ const assertAutotrackHierarchy = async (expectedName, expectedProps) => {
       t: expectedName,
       // Convert { key1: 'value1', key2: 'value2'} to ['key1', 'value1', 'key2', 'value2'] for
       // custom props.
-      k: _(expectedProps)
-        .map((value, key) => [key, value])
-        .flatten()
-        .value(),
+      k: _.flatMap(expectedProps, (value, key) => [key, value]),
     });
   } else {
     throw new Error(`Unknown device type: ${device.getPlatform()}`);

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -56,6 +56,8 @@ const assertAutotrackHierarchy = async (expectedName, expectedProps) => {
   } else if (device.getPlatform() === 'ios') {
     return assertIosPixel({
       t: expectedName,
+      // Convert { key1: 'value1', key2: 'value2'} to ['key1', 'value1', 'key2', 'value2'] for
+      // custom props.
       k: _(expectedProps)
         .map((value, key) => [key, value])
         .flatten()

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -43,7 +43,7 @@ const assertAndroidAutotrackHierarchy = async (expectedName, expectedProps) => {
       custom: {
         name: expectedName,
         properties: _.mapValues(expectedProps, value => {
-          string: value;
+          return { string: value };
         }),
       },
     },


### PR DESCRIPTION
Currently, our RN test utils are hard coded to assert the props `touchableHierarchy` and `targetText`.  This doesn't work when these props are different or not present (e.g. `targetText` is not a prop for `Switch` components, since these don't have any inner text).

Instead, we should take a generic `expectedProps` object, and expand this to the correct format for ios/android when making the event assertion.

~Note: this has been tested on iOS, but not on android (having trouble with my local android build for TestDriver), and so should not yet be merged~.  This has now been successfully tested on android