### PR TITLE
[Slack link] Fix Detox+Android tests.

### DIFF
--- a/examples/TestDriver/android/app/src/androidTest/java/com/testdriver/DetoxTest.java
+++ b/examples/TestDriver/android/app/src/androidTest/java/com/testdriver/DetoxTest.java
@@ -1,18 +1,14 @@
 package com.testdriver;
 
-import android.support.test.filters.LargeTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
-
 import com.wix.detox.Detox;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-/**
- * Created by simonracz on 28/05/2017.
- */
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest


### PR DESCRIPTION
The Detox upgrades implemented in 75544e713bc0a171a6c0bea42507f3ffb7cb4a69 were incomplete; this gets Detox+Android working locally.