### PR TITLE
Remove code inserted by extra 'react-native link' for the RN Gesture Handler

### DIFF
--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -146,7 +146,6 @@ android {
 }
 
 dependencies {
-    compile project(':react-native-gesture-handler')
     implementation project(':react-native-gesture-handler')
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"

--- a/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
+++ b/examples/TestDriver/android/app/src/main/java/com/testdriver/MainApplication.java
@@ -4,7 +4,6 @@ import android.app.Application;
 
 import com.facebook.react.ReactApplication;
 import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
-import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
 import com.heapanalytics.android.internal.HeapImpl;
 import com.heapanalytics.reactnative.RNHeapLibraryPackage;
 import com.facebook.react.ReactNativeHost;
@@ -27,7 +26,6 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
         new MainReactPackage(),
-            new RNGestureHandlerPackage(),
         new RNGestureHandlerPackage(),
         new RNHeapLibraryPackage()
       );

--- a/examples/TestDriver/android/settings.gradle
+++ b/examples/TestDriver/android/settings.gradle
@@ -1,8 +1,6 @@
 rootProject.name = 'TestDriver'
 include ':react-native-gesture-handler'
 project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
-include ':react-native-gesture-handler'
-project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
 include ':@heap_react-native-heap'
 project(':@heap_react-native-heap').projectDir = new File(rootProject.projectDir, '../node_modules/@heap/react-native-heap/android')
 


### PR DESCRIPTION
While attempting to "fix" `TestDriver` in https://github.com/heap/react-native-heap/pull/71, an extra `react-native link react-native-gesture-handler` was performed, which inserted duplicate code, and led to runtime errors related to the code duplication.

Remove this extra code.

We should also consider looking into getting `react-native link` to recognize that this package is already linked (although with autolinking on the horizon, it's unclear if this would really be worth it)