### PR TITLE
E2E tests for RN Switch component

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -230,12 +230,10 @@ describe('Basic React Native and Interaction Support', () => {
       const expectedHierarchy =
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|TouchableOpacity;[testID=touchableOpacityText];|';
       const expectedTargetText = 'Touchable Opacity Foo';
-      await rnTestUtil.assertAutotrackHierarchy(
-      'touchableHandlePress',
-        {
-          touchableHierarchy: expectedHierarchy,
-          targetText: expectedTargetText,
-        });
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        touchableHierarchy: expectedHierarchy,
+        targetText: expectedTargetText,
+      });
     });
 
     it("should autotrack 'TouchableHighlight's", async () => {
@@ -271,19 +269,17 @@ describe('Basic React Native and Interaction Support', () => {
     it("should autotrack 'Switch's", async () => {
       const expectedHierarchy =
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|Switch;[testID=switch];|';
-      await rnTestUtil.assertAutotrackHierarchy(
-        '_handleChange',
-        { touchableHierarchy: expectedHierarchy},
-      );
+      await rnTestUtil.assertAutotrackHierarchy('_handleChange', {
+        touchableHierarchy: expectedHierarchy,
+      });
     });
 
     it("should autotrack NativeBase 'Switch's", async () => {
       const expectedHierarchy =
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|StyledComponent;[testID=nbSwitch];|Switch;[testID=nbSwitch];|Switch;[testID=nbSwitch];|';
-      await rnTestUtil.assertAutotrackHierarchy(
-        '_handleChange',
-        { touchableHierarchy: expectedHierarchy},
-      );
+      await rnTestUtil.assertAutotrackHierarchy('_handleChange', {
+        touchableHierarchy: expectedHierarchy,
+      });
     });
   });
 });

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -39,10 +39,13 @@ const doTestActions = async () => {
     await element(by.id('touchableNativeFeedbackText')).tap();
   }
 
+  await element(by.id('switch')).tap();
+  await element(by.id('nbSwitch')).tap();
+
   await element(by.id('basicsSentinel')).tap();
 };
 
-describe('Basic React Native and Touchable Support', () => {
+describe('Basic React Native and Interaction Support', () => {
   before(done => {
     db.orm.connection.sharedRedis().flushall(done);
   });
@@ -263,6 +266,24 @@ describe('Basic React Native and Touchable Support', () => {
         touchableHierarchy: expectedHierarchy,
         targetText: expectedTargetText,
       });
+    });
+
+    it("should autotrack 'Switch's", async () => {
+      const expectedHierarchy =
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|Switch;[testID=switch];|';
+      await rnTestUtil.assertAutotrackHierarchy(
+        '_handleChange',
+        { touchableHierarchy: expectedHierarchy},
+      );
+    });
+
+    it("should autotrack NativeBase 'Switch's", async () => {
+      const expectedHierarchy =
+        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|StyledComponent;[testID=nbSwitch];|Switch;[testID=nbSwitch];|Switch;[testID=nbSwitch];|';
+      await rnTestUtil.assertAutotrackHierarchy(
+        '_handleChange',
+        { touchableHierarchy: expectedHierarchy},
+      );
     });
   });
 });

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -22,7 +22,7 @@ class BasicsPage extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <NbSwitch testID="switch" onValueChange={() => console.log('stuff')} />
+        <NbSwitch testID="nbSwitch" onValueChange={() => console.log('stuff')} />
         <Switch testID="switch" onValueChange={() => console.log('stuff')} />
         <Button
           testID="track1"

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -22,7 +22,10 @@ class BasicsPage extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <NbSwitch testID="nbSwitch" onValueChange={() => console.log('stuff')} />
+        <NbSwitch
+          testID="nbSwitch"
+          onValueChange={() => console.log('stuff')}
+        />
         <Switch testID="switch" onValueChange={() => console.log('stuff')} />
         <Button
           testID="track1"

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -22,11 +22,8 @@ class BasicsPage extends Component {
   render() {
     return (
       <View style={styles.container}>
-        <NbSwitch
-          testID="nbSwitch"
-          onValueChange={() => console.log('stuff')}
-        />
-        <Switch testID="switch" onValueChange={() => console.log('stuff')} />
+        <NbSwitch testID="nbSwitch" />
+        <Switch testID="switch" />
         <Button
           testID="track1"
           title="Call Track1"

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -3,8 +3,6 @@
 const t = require('babel-types');
 const template = require('babel-template');
 
-const SWITCH_COMPONENT_NAME = 'switch';
-
 // Used to record whether certain methods/components have been instrumented.
 // :TODO: (jmtaber129): Determine whether we actually need this once we figure out the unexpected
 // behavior with the instrumented Switch node being visited multiple times.
@@ -166,7 +164,7 @@ const isSwitchNode = (path) => {
 }
 
 const instrumentSwitchComponent = path => {
-  if (instrumentedComponentNodes.has(SWITCH_COMPONENT_NAME)) {
+  if (instrumentedComponentNodes.has(path)) {
     // We already instrumented the switch, so do nothing.
     return;
   }
@@ -191,7 +189,7 @@ const instrumentSwitchComponent = path => {
   // node we're instrumenting to be visited multiple times. To avoid unintentionally wrapping the
   // same method multiple times, record that we've instrumented the switch.
   // :TODO: (jmtabe129): Remove this once we figure out what's going on here.
-  instrumentedComponentNodes.add(SWITCH_COMPONENT_NAME);
+  instrumentedComponentNodes.add(path);
 };
 
 const instrumentStartup = path => {


### PR DESCRIPTION
This PR includes:
* e2e tests for switches
* a fix for a bug that was uncovered by the tests

Specifically, the bug occurred when the bundler generated bundles for both platforms within the same process.  Because the `instrumentedComponentNodes` set is not re-initialized for each new platform, the following happens:
* generate bundle for iOS
* mark 'Switch' as visited in `instrumentedComponentNodes`
* generate bundle for android
* 'Switch' is contained in `instrumentedComponentNodes`, so don't instrument `Switch`

By adding the `path` object to the set, rather than the string representation 'Switch', the key will be different between platforms, but still the same for subsequent visits to the same node within the same platform (i.e. keys will be different between iOS and android, but the key will be the same when the node is visited multiple times within a single iOS traversal).