### PR TITLE
[HEAP-8830] Don't allow errors thrown by the Heap library to crash the client app.

### DIFF
--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -10,10 +10,14 @@ describe('The Heap object', () => {
     mockAddUserProperties,
     mockAddEventProperties,
     mockRemoveEventProperty,
-    mockClearEventProperties;
+    mockClearEventProperties,
+    throwFn;
 
   beforeAll(() => {
     jest.mock('react-native');
+    throwFn = (...args) => {
+      throw "Error!";
+    };
   });
 
   beforeEach(() => {
@@ -87,6 +91,11 @@ describe('The Heap object', () => {
       Heap.track('foo');
       expect(mockTrack.mock.calls.length).toBe(0);
     });
+
+    it("doesn't crash if an error is thrown", () => {
+      mockTrack.mockImplementation(throwFn);
+      expect(() => Heap.track('foo')).not.toThrow();
+    });
   });
 
   describe('Other functions', () => {
@@ -125,5 +134,37 @@ describe('The Heap object', () => {
       expect(mockClearEventProperties.mock.calls.length).toBe(1);
       expect(mockRemoveEventProperty.mock.calls[0]).toBeUndefined();
     });
+  });
+
+  describe('Preventing crashes', () => {
+    it('setAppId - prevents errors from bubbling up', () => {
+      mockSetAppId.mockImplementation(throwFn);
+      expect(() => Heap.setAppId('foo')).not.toThrow();
+    });
+
+    it('identify - prevents errors from bubbling up', () => {
+      mockIdentify.mockImplementation(throwFn);
+      expect(() => Heap.identify('foo')).not.toThrow();
+    });
+
+    it('addUserProperties - prevents errors from bubbling up', () => {
+      mockAddUserProperties.mockImplementation(throwFn);
+      expect(() => Heap.addUserProperties({ foo: 'bar' })).not.toThrow();
+    });
+
+    it('addEventProperties - prevents errors from bubbling up', () => {
+      mockAddEventProperties.mockImplementation(throwFn);
+      expect(() => Heap.addEventProperties({ foo: 'bar' })).not.toThrow();
+    });
+
+    it('removeEventProperty - prevents errors from bubbling up', () => {
+      mockRemoveEventProperty.mockImplementation(throwFn);
+      expect(() => Heap.removeEventProperty('foo')).not.toThrow();
+    });
+
+    it('clearEventProperties - prevents errors from bubbling up', () => {
+      mockClearEventProperties.mockImplementation(throwFn);
+      expect(() => Heap.clearEventProperties()).not.toThrow();
+    })
   });
 });

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { bail, bailOnError } from '../util/bailer';
 
 const EVENT_TYPE = 'reactNavigationScreenview';
 
@@ -23,9 +24,20 @@ export const withReactNavigationAutotrack = track => AppContainer => {
     }
 
     render() {
+      try {
+        return this._render();
+      } catch(e) {
+        bail(e);
+        return (
+          <AppContainer/>
+        );
+      }
+    }
+
+    _render() {
       return (
         <AppContainer
-          ref={navigatorRef => {
+          ref={bailOnError(navigatorRef => {
             if (this.topLevelNavigator !== navigatorRef) {
               console.log(
                 'Heap: React Navigation is instrumented for autocapture.'
@@ -33,8 +45,8 @@ export const withReactNavigationAutotrack = track => AppContainer => {
               this.topLevelNavigator = navigatorRef;
               this.trackInitialRoute();
             }
-          }}
-          onNavigationStateChange={(prev, next, action) => {
+          })}
+          onNavigationStateChange={bailOnError((prev, next, action) => {
             const prevScreenRoute = getActiveRouteName(prev);
             const nextScreenRoute = getActiveRouteName(next);
             if (prevScreenRoute !== nextScreenRoute) {
@@ -44,7 +56,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
                 type: action.type,
               });
             }
-          }}
+          })}
         >
           {this.props.children}
         </AppContainer>

--- a/js/util/bailer.ts
+++ b/js/util/bailer.ts
@@ -1,0 +1,23 @@
+const bail = (error: Error) => {
+    // Swallow all errors.
+    // TODO: Turn off Heap tracking for a while (short-circuit?)
+
+    // KLUDGE: These properties don't show up if you `console.warn` the error object directly.
+    const errorData = {
+        name: error.name,
+        message: error.message,
+        stack: error.stack
+    };
+
+    console.warn("The Heap library has crashed with an exception.", errorData);
+};
+
+const bailOnError = f => (...args) => {
+    try {
+        return f(...args);
+    } catch(e) {
+        bail(e);
+    }
+};
+
+export { bail, bailOnError };


### PR DESCRIPTION
- Errors are swallowed in production and surfaced in debug builds.
- This covers the public API and the autotracking code.