### PR TITLE
[HEAP-8474] Set AUP/AEP props to '{}' if null

### DIFF
--- a/js/Heap.js
+++ b/js/Heap.js
@@ -33,12 +33,14 @@ export default {
   // User Properties
   identify: bailOnError(identity => RNHeap.identify(identity)),
   addUserProperties: bailOnError(properties => {
-    RNHeap.addUserProperties(flatten(properties));
+    const payload = properties || {};
+    RNHeap.addUserProperties(flatten(payload));
   }),
 
   // Event Properties
   addEventProperties: bailOnError(properties => {
-    RNHeap.addEventProperties(flatten(properties));
+    const payload = properties || {};
+    RNHeap.addEventProperties(flatten(payload));
   }),
   removeEventProperty: bailOnError(property =>
     RNHeap.removeEventProperty(property)


### PR DESCRIPTION
This isn't currently necessary to prevent crashes (since the `bailOnError` method will catch any errors), but once `bailOnError` actually bails (rather than just swallow errors), this will be necessary to keep Heap from bailing when the argument to these methods is `null` or `undefined`.