### PR TITLE
[HEAP-9052] Update documentation to cover auto-initialization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,81 +23,10 @@ For autotrack, add the following plugins to your `.babelrc` or `babel.config.js`
 }
 ```
 
-### Manual setup - iOS with Cocoapods
+## Installation & Setup
 
-If you don't have a Podfile in the `ios` folder of your React Native project, follow this guide to create one: https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies
-
-Add the following to your Podfile:
-
-```ruby
-pod "react-native-heap", path: "../node_modules/@heap/react-native-heap"
-```
-
-Then run:
-
-```bash
-pod install
-```
-
-You're done! :tada:
-
-### Manual setup - iOS without Cocoapods
-
-All terminal commands assume you are in the top-level directory of your React Native project.
-
-1. Locate the Xcode project for RNHeap: `open node_modules/@heap/react-native-heap/ios` . You should see a Finder window containing the `RNHeap.xcodeproj` file.
-1. Open the Xcode project for your native app, in the `ios` directory of your project.
-1. Drag the `RNHeap.xcodeproj` file from the Finder window into the "Libraries" group of your Xcode project.
-1. Select your project name in the Xcode project navigator. Select the "Build Phases" tab for your app's target.
-1. Expand the build phase called "Link Binary With Libraries". In the project navigator on the left, expand the `RNHeap.xcodeproj` entry, and find `libRNHeap.a` in the "Products" group. The icon for `libRNHeap.a` should look like a little building with columns.
-1. Drag the `libRNHeap.a` file into the list of other libraries to be linked.
-1. Expand the build phase called "Copy Bundle Resources". In the project navigator on the left, expand the `RNHeap.xcodeproj` entry, and find `HeapSettings.bundle`. Drag this into the list of bundle resources to be copied.
-
-**NOTE**: Using `react-native link` is not currently supported
-
-### Manual setup - Android
-
-In some cases, simply doing `react-native link` will correctly set up the tracker on Android.
-However, if you encounter any issues (either with the command itself or at compile-time/run-time),
-you should revert any changes made by `react-native link` and try the following steps, instead.
-
-Add the following to your `settings.gradle`:
-
-```groovy
-include ':react-native-heap'
-project(':react-native-heap').projectDir =
-    new File(rootProject.projectDir, '../node_modules/@heap/react-native-heap/android')
-```
-
-Then add the following to `app/build.gradle`:
-
-```groovy
-implementation project(':react-native-heap')
-```
-
-Import the package and add it to your app's MainApplication:
-
-```java
-
-@Override
-import com.heapanalytics.reactnative.RNHeapLibraryPackage;
-...
-protected List<ReactPackage> getPackages() {
-  return Arrays.<ReactPackage>asList(
-    new MainReactPackage(),
-    new RNHeapLibraryPackage()
-  );
-}
-```
-
-If you are seeing runtime warnings at startup mentioning `Heap: Could not find BuildConfig`, add the
-following line to the resources section of `res/values/strings.xml`:
-
-```xml
-<string name="com.heapanalytics.android.buildConfigPkgName">com.your_package_name</string>
-```
-
-and replace `com.your_package_name` with the package name from the manifest tag in `AndroidManifest.xml`.
+- [iOS](docs/ios-setup.md)
+- [Android](docs/android-setup.md)
 
 ## Usage
 
@@ -105,7 +34,7 @@ and replace `com.your_package_name` with the package name from the manifest tag 
 // Import Heap.
 import Heap from '@heap/react-native-heap';
 
-// Start Heap.
+// Start Heap if not using auto-initialization.
 Heap.setAppId('my-app-id');
 
 // Identify your user.
@@ -121,39 +50,6 @@ Heap.clearEventProperties();
 
 // To track an event, use:
 Heap.track('signed-up', { isPaid: true, amount: 20 });
-```
-
-## Troubleshooting
-
-### iOS Build Issues
-
-**Build failures due to file not found errors**
-
-Build failures may occur if your Podfile does not specify the path to your local React pod, which should be added (and any other necessary subspecs) to your Podfile. You can find more information (and an example) in the [official React Native docs](https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies). Failing to do so will result in the `pod install` step installing an additional React dependency (version 0.11 by default). You can confirm if correct React version is being used in Podfile.lock.
-
-**Linker error due to `Undefined symbols for architecture x86_64:`**
-
-This occurs at build time, and in its entirety, looks like this in the build log:
-
-```
-Undefined symbols for architecture x86_64:
-  "_OBJC_CLASS_$_Heap", referenced from:
-      objc-class-ref in RNHeap.o
-ld: symbol(s) not found for architecture x86_64
-clang: error: linker command failed with exit code 1 (use -v to see invocation)
-```
-
-This may appear if the `Podfile` contains a `use_frameworks!` directive. One solution is to add the following at the very end of your `Podfile`:
-
-```ruby
-# Force react-native-heap to be built as a static framework.
-# Based on comments at https://github.com/CocoaPods/CocoaPods/issues/7428 .
-pre_install do |installer|
-    pod = installer.pod_targets.find { |p| p.name == 'react-native-heap'}
-    def pod.static_framework?
-        true
-    end
-end
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ For autotrack, add the following plugins to your `.babelrc` or `babel.config.js`
 // Import Heap.
 import Heap from '@heap/react-native-heap';
 
-// Start Heap if not using auto-initialization.
-Heap.setAppId('my-app-id');
-
 // Identify your user.
 Heap.identify('123456');
 Heap.addUserProperties({ name: 'John', age: 54 });

--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -1,0 +1,90 @@
+# Installation
+
+In some cases, simply doing `react-native link` will correctly set up the tracker on Android.
+However, if you encounter any issues (either with the command itself or at compile-time/run-time),
+you should revert any changes made by `react-native link` and try the following steps, instead.
+
+Add the following to your `settings.gradle`:
+
+  ```groovy
+  include ':react-native-heap'
+  project(':react-native-heap').projectDir =
+      new File(rootProject.projectDir, '../node_modules/@heap/react-native-heap/android')
+  ```
+
+Then add the following to `app/build.gradle`:
+
+  ```groovy
+  implementation project(':react-native-heap')
+  ```
+
+Import the package and add it to your app's MainApplication:
+
+  ```java
+  @Override
+  import com.heapanalytics.reactnative.RNHeapLibraryPackage;
+  ...
+  protected List<ReactPackage> getPackages() {
+    return Arrays.<ReactPackage>asList(
+      new MainReactPackage(),
+      new RNHeapLibraryPackage()
+    );
+  }
+  ```
+
+If you are seeing runtime warnings at startup mentioning `Heap: Could not find BuildConfig`, add the
+following line to the resources section of `res/values/strings.xml`:
+
+  ```xml
+  <string name="com.heapanalytics.android.buildConfigPkgName">com.your_package_name</string>
+  ```
+
+and replace `com.your_package_name` with the package name from the manifest tag in `AndroidManifest.xml`.
+
+# Initialization
+
+- This library needs to be initialized so events are sent to the right application/environment ID. 
+Place a `heap.config.json` file at the root of your application's repository with this structure, substituting your own application/environment IDs.
+
+  ```json
+  {
+    "default": {
+      "heapAutoInit": true
+    },
+    "dev": {
+      "heapAutoInit": true,
+      "heapAppId": "11"
+    },
+    "prod": {
+      "heapAppId": "12",
+      "heapAutoInit": true
+    }
+  }
+  ```
+
+- Note that different application/environment IDs can be set for development and production. Heap can also be enabled/disabled on a per-environment basis. Values in `default` are used if a key is missing in either `dev` or `prod`.
+
+## Manual Initialization
+
+- If you'd like to skip auto-initialization, call `Heap.setAppId` with an application/environment ID.
+
+  ```javascript
+  import Heap from '@heap/react-native-heap';
+  Heap.setAppId('my-app-id');
+  ```
+
+- In addition, find the `MainActivity.java` file, which is React Native's Android-specific entry point. This file is typically present in a subfolder of `android/app/src/main/java/`. Add an `onCreate` method containing:
+
+  ```java
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+      super.onCreate(savedInstanceState);
+      RNHeap.init(getApplicationContext(), "<app-id>");
+  }
+  ```
+- And the following imports:
+
+  ```java
+  import com.heapanalytics.reactnative.RNHeap;
+  import android.os.Bundle;
+  ```

--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -41,7 +41,7 @@ following line to the resources section of `res/values/strings.xml`:
 
 and replace `com.your_package_name` with the package name from the manifest tag in `AndroidManifest.xml`.
 
-# Initialization
+# Confguration
 
 - This library needs to be initialized so events are sent to the right application/environment ID. 
 Place a `heap.config.json` file at the root of your application's repository with this structure, substituting your own application/environment IDs.
@@ -64,16 +64,25 @@ Place a `heap.config.json` file at the root of your application's repository wit
 
 - Note that different application/environment IDs can be set for development and production. Heap can also be enabled/disabled on a per-environment basis. Values in `default` are used if a key is missing in either `dev` or `prod`.
 
+- The library distinguishes between `dev` and `prod` builds using the [`__DEV__` variable](https://facebook.github.io/react-native/docs/javascript-environment#polyfills).
+
 ## Manual Initialization
 
-- If you'd like to skip auto-initialization, call `Heap.setAppId` with an application/environment ID.
+- If you'd like finer-grained control over when the Heap library initializes, call `Heap.setAppId` with an application/environment ID. (Most users won't need to do this.)
 
   ```javascript
   import Heap from '@heap/react-native-heap';
   Heap.setAppId('my-app-id');
   ```
 
-- In addition, find the `MainActivity.java` file, which is React Native's Android-specific entry point. This file is typically present in a subfolder of `android/app/src/main/java/`. Add an `onCreate` method containing:
+- In addition, find the `MainActivity.java` file, which is React Native's Android-specific entry point. This file is typically present in a subfolder of `android/app/src/main/java/`. Add the following imports:
+
+  ```java
+  import com.heapanalytics.reactnative.RNHeap;
+  import android.os.Bundle;
+  ```
+
+- And add an `onCreate` method containing the following. If an `onCreate` method already exists, simply add the `RNHeap.init` line to it.
 
   ```java
   @Override
@@ -81,10 +90,4 @@ Place a `heap.config.json` file at the root of your application's repository wit
       super.onCreate(savedInstanceState);
       RNHeap.init(getApplicationContext(), "<app-id>");
   }
-  ```
-- And the following imports:
-
-  ```java
-  import com.heapanalytics.reactnative.RNHeap;
-  import android.os.Bundle;
   ```

--- a/docs/ios-setup.md
+++ b/docs/ios-setup.md
@@ -32,7 +32,7 @@ All terminal commands assume you are in the top-level directory of your React Na
 
 **NOTE**: Using `react-native link` is not currently supported
 
-# Initialization
+# Configuration
 
 - This library needs to be initialized so events are sent to the right application/environment ID. 
 Place a `heap.config.json` file at the root of your application's repository with this structure, substituting your own application/environment IDs.
@@ -55,16 +55,18 @@ Place a `heap.config.json` file at the root of your application's repository wit
 
 - Note that different application/environment IDs can be set for development and production. Heap can also be enabled/disabled on a per-environment basis. Values in `default` are used if a key is missing in either `dev` or `prod`.
 
+- The library distinguishes between `dev` and `prod` builds using the [`__DEV__` variable](https://facebook.github.io/react-native/docs/javascript-environment#polyfills).
+
 ## Manual Initialization
 
-- If you'd like to skip auto-initialization, simply call `Heap.setAppId` with an application/environment ID.
+- If you'd like finer-grained control over when the Heap library initializes, call `Heap.setAppId` with an application/environment ID. (Most users won't need to do this.)
 
   ```javascript
   import Heap from '@heap/react-native-heap';
   Heap.setAppId('my-app-id');
   ```
 
-- Note that manual initialization [on Android](./android-setup.md#manual-initialization) is slightly more involved.
+- Note that manual initialization [on Android](./android-setup.md#manual-initialization) requires additional steps.
 
 # Build Issues
 

--- a/docs/ios-setup.md
+++ b/docs/ios-setup.md
@@ -1,0 +1,98 @@
+# Installation
+
+## With CocoaPods
+
+If you don't have a Podfile in the `ios` folder of your React Native project, follow this guide to create one: https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies
+
+Add the following to your Podfile:
+
+  ```ruby
+  pod "react-native-heap", path: "../node_modules/@heap/react-native-heap"
+  ```
+
+Then run:
+
+  ```bash
+  pod install
+  ```
+
+You're done! :tada:
+
+## Without Cocoapods
+
+All terminal commands assume you are in the top-level directory of your React Native project.
+
+1. Locate the Xcode project for RNHeap: `open node_modules/@heap/react-native-heap/ios` . You should see a Finder window containing the `RNHeap.xcodeproj` file.
+1. Open the Xcode project for your native app, in the `ios` directory of your project.
+1. Drag the `RNHeap.xcodeproj` file from the Finder window into the "Libraries" group of your Xcode project.
+1. Select your project name in the Xcode project navigator. Select the "Build Phases" tab for your app's target.
+1. Expand the build phase called "Link Binary With Libraries". In the project navigator on the left, expand the `RNHeap.xcodeproj` entry, and find `libRNHeap.a` in the "Products" group. The icon for `libRNHeap.a` should look like a little building with columns.
+1. Drag the `libRNHeap.a` file into the list of other libraries to be linked.
+1. Expand the build phase called "Copy Bundle Resources". In the project navigator on the left, expand the `RNHeap.xcodeproj` entry, and find `HeapSettings.bundle`. Drag this into the list of bundle resources to be copied.
+
+**NOTE**: Using `react-native link` is not currently supported
+
+# Initialization
+
+- This library needs to be initialized so events are sent to the right application/environment ID. 
+Place a `heap.config.json` file at the root of your application's repository with this structure, substituting your own application/environment IDs.
+
+  ```json
+  {
+    "default": {
+      "heapAutoInit": true
+    },
+    "dev": {
+      "heapAutoInit": true,
+      "heapAppId": "11"
+    },
+    "prod": {
+      "heapAppId": "12",
+      "heapAutoInit": true
+    }
+  }
+  ```
+
+- Note that different application/environment IDs can be set for development and production. Heap can also be enabled/disabled on a per-environment basis. Values in `default` are used if a key is missing in either `dev` or `prod`.
+
+## Manual Initialization
+
+- If you'd like to skip auto-initialization, simply call `Heap.setAppId` with an application/environment ID.
+
+  ```javascript
+  import Heap from '@heap/react-native-heap';
+  Heap.setAppId('my-app-id');
+  ```
+
+- Note that manual initialization [on Android](./android-setup.md#manual-initialization) is slightly more involved.
+
+# Build Issues
+
+**Build failures due to file not found errors**
+
+Build failures may occur if your Podfile does not specify the path to your local React pod, which should be added (and any other necessary subspecs) to your Podfile. You can find more information (and an example) in the [official React Native docs](https://facebook.github.io/react-native/docs/integration-with-existing-apps#configuring-cocoapods-dependencies). Failing to do so will result in the `pod install` step installing an additional React dependency (version 0.11 by default). You can confirm if correct React version is being used in Podfile.lock.
+
+**Linker error due to `Undefined symbols for architecture x86_64:`**
+
+This occurs at build time, and in its entirety, looks like this in the build log:
+
+```
+Undefined symbols for architecture x86_64:
+  "_OBJC_CLASS_$_Heap", referenced from:
+      objc-class-ref in RNHeap.o
+ld: symbol(s) not found for architecture x86_64
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+```
+
+This may appear if the `Podfile` contains a `use_frameworks!` directive. One solution is to add the following at the very end of your `Podfile`:
+
+```ruby
+# Force react-native-heap to be built as a static framework.
+# Based on comments at https://github.com/CocoaPods/CocoaPods/issues/7428 .
+pre_install do |installer|
+    pod = installer.pod_targets.find { |p| p.name == 'react-native-heap'}
+    def pod.static_framework?
+        true
+    end
+end
+```


### PR DESCRIPTION
I split iOS-specific and Android-specific instructions into separate files; doing this in one file was getting a bit unwieldy.