### PR TITLE
[HEAP-9245] Add 'HeapIgnoreTargetText' convenience component

### DIFF
--- a/js/Heap.js
+++ b/js/Heap.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { NativeModules } from 'react-native';
 
-import { HeapIgnore, withHeapIgnore } from './autotrack/heapIgnore';
+import { HeapIgnore, HeapIgnoreTargetText, withHeapIgnore } from './autotrack/heapIgnore';
 import { autotrackPress } from './autotrack/touchables';
 import { autotrackSwitchChange } from './autotrack/switches';
 import { checkDisplayNamePlugin } from './util/checkDisplayNames';
@@ -27,7 +27,7 @@ const track = bailOnError((event, payload) => {
   }
 });
 
-export { HeapIgnore };
+export { HeapIgnore, HeapIgnoreTargetText };
 
 export default {
   // App Properties
@@ -62,5 +62,6 @@ export default {
   autotrackSwitchChange: bailOnError(autotrackSwitchChange(track)),
   withReactNavigationAutotrack: withReactNavigationAutotrack(track),
   Ignore: HeapIgnore,
+  IgnoreTargetText: HeapIgnoreTargetText,
   withHeapIgnore,
 };

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -2,7 +2,11 @@
 import React from 'react';
 import { NativeModules } from 'react-native';
 
-import { HeapIgnore, HeapIgnoreTargetText, withHeapIgnore } from './autotrack/heapIgnore';
+import {
+  HeapIgnore,
+  HeapIgnoreTargetText,
+  withHeapIgnore,
+} from './autotrack/heapIgnore';
 import { autotrackPress } from './autotrack/touchables';
 import { autotrackSwitchChange } from './autotrack/switches';
 import { checkDisplayNamePlugin } from './util/checkDisplayNames';

--- a/js/autotrack/__tests__/heapIgnore.spec.js
+++ b/js/autotrack/__tests__/heapIgnore.spec.js
@@ -7,7 +7,11 @@ const foo = require('react-native');
 import { shallow, mount, render } from 'enzyme';
 
 import { getBaseComponentProps } from '../common';
-import { HeapIgnore, HeapIgnoreTargetText, withHeapIgnore } from '../heapIgnore';
+import {
+  HeapIgnore,
+  HeapIgnoreTargetText,
+  withHeapIgnore,
+} from '../heapIgnore';
 
 jest.unmock('react-native');
 

--- a/js/autotrack/__tests__/heapIgnore.spec.js
+++ b/js/autotrack/__tests__/heapIgnore.spec.js
@@ -7,7 +7,7 @@ const foo = require('react-native');
 import { shallow, mount, render } from 'enzyme';
 
 import { getBaseComponentProps } from '../common';
-import { HeapIgnore, withHeapIgnore } from '../heapIgnore';
+import { HeapIgnore, HeapIgnoreTargetText, withHeapIgnore } from '../heapIgnore';
 
 jest.unmock('react-native');
 
@@ -202,6 +202,24 @@ describe('Common autotrack utils', () => {
       expect(normalProps).toEqual({
         touchableHierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|_class;[testID=targetElement];|HeapIgnore;|',
+      });
+    });
+
+    it('Ignores target text via convenience component', () => {
+      const wrapper = mount(
+        <Foo>
+          <HeapIgnoreTargetText>
+            <Text testID="targetElement">{'foobar'}</Text>
+          </HeapIgnoreTargetText>
+        </Foo>
+      );
+      const normalComponent = wrapper
+        .find({ testID: 'targetElement' })
+        .filter(Text);
+      const normalProps = getBaseComponentProps(normalComponent.instance());
+      expect(normalProps).toEqual({
+        touchableHierarchy:
+          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnoreTargetText;|HeapIgnore;|Text;[testID=targetElement];|',
       });
     });
   });

--- a/js/autotrack/heapIgnore.js
+++ b/js/autotrack/heapIgnore.js
@@ -14,6 +14,7 @@ export const HeapIgnoreTargetText = props => {
       allowInteraction={true}
       allowInnerHierarchy={true}
       allowAllProps={true}
+      allowTargetText={false}
     >
       {props.children}
     </HeapIgnore>

--- a/js/autotrack/heapIgnore.js
+++ b/js/autotrack/heapIgnore.js
@@ -7,6 +7,19 @@ export const HeapIgnore = props => {
   return props.children;
 };
 
+// Convenience component for only ignoring target text.
+export const HeapIgnoreTargetText = props => {
+  return (
+    <HeapIgnore
+      allowInteraction={true}
+      allowInnerHierarchy={true}
+      allowAllProps={true}
+    >
+      {props.children}
+    </HeapIgnore>
+  );
+};
+
 export const withHeapIgnore = (IgnoredComponent, heapIgnoreConfig) => {
   return class extends React.Component {
     render() {


### PR DESCRIPTION
One HeapIgnore use case we expect to be somewhat common is to ignore a component subtree's target text and nothing else.  With the current `HeapIgnore` component, this would look like:
```
<HeapIgnore
  allowInteraction={true}
  allowInnerHierarchy={true}
  allowAllProps={true}
>
  <MySensitiveTextComponent />
</HeapIgnore>
```

To reduce the boilerplate for such a component, this PR adds a `HeapIgnoreTargetText` convenience component that is the equivalent of the above snippet, without the config:
```
<HeapIgnoreTargetText>
  <MySensitiveTextComponent />
</HeapIgnoreTargetText>
```

Note that one side effect of this particular implementation is that the presence of the `HeapIgnoreTargetText` component leads to a `HeapIgnoreTargetText;|HeapIgnore;|` in the resulting component hierarchy, rather than just `HeapIgnoreTargetText;|`.