### PR TITLE
Pass through props for React Navigation autocapture HOC

### DIFF
--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -55,6 +55,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
               });
             }
           })}
+          {...this.props}
         >
           {this.props.children}
         </AppContainer>


### PR DESCRIPTION
Currently, the HOC for react navigation autocapture (`withReactNavigationAutotrack`) doesn't pass through props.  This effectively disallows passing props into the navigation container wrapped by the HOC.

Pass props to the container wrapped by the HOC.

Fixes #91