### PR TITLE
Fix android assertion on HeapIgnore

### DIFF
--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -37,31 +37,10 @@ describe('HeapIgnore', () => {
     await rnTestUtil.pollForSentinel('HeapIgnore');
   });
 
-  it(':ios: should ignore the interaction', async () => {
+  it('should ignore the interaction', async () => {
     // Get all the events from redis, and assert that none of the requests match the ignored
     // interaction.
-    const { err, res } = await new Promise((resolve, reject) => {
-      testUtil.findEventInRedisRequests({}, (err, res) => {
-        resolve({ err, res });
-      });
-    });
-
-    assert.not.exist(err);
-    assert(res.length).not.equal(0);
-
-    // The ignored interaction is within an instantiation of the "Foo" component, so assert that no
-    // part of the event requests includes this as part of its hierarchy.
-    assert(JSON.stringify(res)).not.match(/Foo;\|/);
-  });
-
-  it(':android: should ignore the interaction', async () => {
-    // Get all the events from redis, and assert that none of the requests match the ignored
-    // interaction.
-    const { err, res } = await new Promise((resolve, reject) => {
-      testUtil.findAndroidEventInRedisRequests({}, (err, res) => {
-        resolve({ err, res });
-      });
-    });
+    const { err, res } = await rnTestUtil.findAllEvents();
 
     assert.not.exist(err);
     assert(res.length).not.equal(0);

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -37,7 +37,7 @@ describe('HeapIgnore', () => {
     await rnTestUtil.pollForSentinel('HeapIgnore');
   });
 
-  it('should ignore the interaction', async () => {
+  it(':ios: should ignore the interaction', async () => {
     // Get all the events from redis, and assert that none of the requests match the ignored
     // interaction.
     const { err, res } = await new Promise((resolve, reject) => {
@@ -51,7 +51,24 @@ describe('HeapIgnore', () => {
 
     // The ignored interaction is within an instantiation of the "Foo" component, so assert that no
     // part of the event requests includes this as part of its hierarchy.
-    assert(JSON.stringify(res)).not.match(/Foo;\|/)
+    assert(JSON.stringify(res)).not.match(/Foo;\|/);
+  });
+
+  it(':android: should ignore the interaction', async () => {
+    // Get all the events from redis, and assert that none of the requests match the ignored
+    // interaction.
+    const { err, res } = await new Promise((resolve, reject) => {
+      testUtil.findAndroidEventInRedisRequests({}, (err, res) => {
+        resolve({ err, res });
+      });
+    });
+
+    assert.not.exist(err);
+    assert(res.length).not.equal(0);
+
+    // The ignored interaction is within an instantiation of the "Foo" component, so assert that no
+    // part of the event requests includes this as part of its hierarchy.
+    assert(JSON.stringify(res)).not.match(/Foo;\|/);
   });
 
   it('should ignore the inner hierarchy', async () => {

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -16,6 +16,23 @@ const assertEvent = (err, res, check) => {
   }
 };
 
+// Get all the events from redis
+const findAllEvents = async () => {
+  return new Promise((resolve, reject) => {
+    if (device.getPlatform() === 'android') {
+      testUtil.findAndroidEventInRedisRequests({}, (err, res) => {
+        resolve({ err, res });
+      });
+    } else if (device.getPlatform() === 'ios') {
+      testUtil.findEventInRedisRequests({}, (err, res) => {
+        resolve({ err, res });
+      });
+    } else {
+      reject(new Error(`Unknown device type: ${device.getPlatform()}`));
+    }
+  });
+};
+
 const assertIosPixel = async (event, check) => {
   const { err, res } = await new Promise((resolve, reject) => {
     testUtil.findEventInRedisRequests(event, (err, res) => {
@@ -174,6 +191,7 @@ pollForSentinel = async (sentinelValue, timeout = 60000) => {
 
 module.exports = {
   assertEvent,
+  findAllEvents,
   assertIosPixel,
   assertAndroidEvent,
   assertAndroidAutotrackHierarchy,


### PR DESCRIPTION
The `findEventInRedisRequests()` method used for assertions that an event did _not_ occur on iOS doesn't work for android, so add an equivalent spec for android that uses the `findAndroidEventInRedisRequests()` method instead.