### PR TITLE
[HEAP-9449] Perform ref forwarding for react nav HOC

### DIFF
--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -71,5 +71,11 @@ describe('Navigation', () => {
         'Navigation/NAVIGATE'
       );
     });
+
+    it("doesn't crash when ref is used for navigation without navigation prop", async () => {
+      await element(by.id('navigate_without_prop')).tap();
+      // Check that app doesn't crash by asserting the button is still visible.
+      await expect(element(by.id('navigate_without_prop'))).toBeVisible();
+    });
   });
 });

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -15,6 +15,12 @@ const doTestActions = async () => {
   await expect(element(by.id('button1'))).toBeVisible();
   await element(by.id('button1')).tap();
   await element(by.id('button2')).tap();
+
+  // :HACK: Break up long URL.
+  // :TODO: Remove once pixel endpoint is handling larger events again.
+  console.log('Waiting 15s to flush iOS events.');
+  await new Promise(resolve => setTimeout(resolve, 15000));
+
   await element(by.id('button3')).tap();
 
   await element(by.id('propextractionSentinel')).tap();

--- a/examples/TestDriver/App.js
+++ b/examples/TestDriver/App.js
@@ -1,13 +1,32 @@
 import React from 'react';
 import { Provider } from 'react-redux';
+import { NavigationActions } from 'react-navigation';
 import { store } from './src/reduxElements';
 import TopNavigator from './src/topNavigator';
+
+let _navigator;
+
+function setTopLevelNavigator(navigatorRef) {
+  _navigator = navigatorRef;
+
+  navigate('Initial');
+}
+
+function navigate(routeName, params) {
+  console.log(_navigator);
+  _navigator.dispatch(
+    NavigationActions.navigate({
+      routeName,
+      params,
+    })
+  );
+}
 
 export default class App extends React.Component {
   render() {
     return (
       <Provider store={store}>
-        <TopNavigator />
+        <TopNavigator ref={setTopLevelNavigator} />
       </Provider>
     );
   }

--- a/examples/TestDriver/App.js
+++ b/examples/TestDriver/App.js
@@ -3,30 +3,13 @@ import { Provider } from 'react-redux';
 import { NavigationActions } from 'react-navigation';
 import { store } from './src/reduxElements';
 import TopNavigator from './src/topNavigator';
-
-let _navigator;
-
-function setTopLevelNavigator(navigatorRef) {
-  _navigator = navigatorRef;
-
-  navigate('Initial');
-}
-
-function navigate(routeName, params) {
-  console.log(_navigator);
-  _navigator.dispatch(
-    NavigationActions.navigate({
-      routeName,
-      params,
-    })
-  );
-}
+import NavigationService from './src/navigatorService';
 
 export default class App extends React.Component {
   render() {
     return (
       <Provider store={store}>
-        <TopNavigator ref={setTopLevelNavigator} />
+        <TopNavigator ref={NavigationService.setTopLevelNavigator} />
       </Provider>
     );
   }

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
-  - RNGestureHandler (1.2.1):
+  - RNGestureHandler (1.3.0):
     - React
   - yoga (0.57.5.React)
 

--- a/examples/TestDriver/src/pages/nav.js
+++ b/examples/TestDriver/src/pages/nav.js
@@ -3,6 +3,7 @@ import { Button, StyleSheet, Text, View } from 'react-native';
 import { createStackNavigator } from 'react-navigation';
 
 import { makeSentinelButton } from '../sentinelUtilities';
+import NavigationService from '../navigatorService';
 
 const BaseView = props => {
   return (
@@ -16,6 +17,11 @@ const BaseView = props => {
         title="Navigate Modal"
         testID="navigate_modal"
         onPress={() => props.navigation.navigate('ModalStack')}
+      />
+      <Button
+        title="Navigate without prop"
+        testID="navigate_without_prop"
+        onPress={() => NavigationService.navigate('Nav')}
       />
       {makeSentinelButton('Nav')}
     </View>


### PR DESCRIPTION
This is needed for users using the [Navigating without navigation prop](https://reactnavigation.org/docs/en/navigating-without-navigation-prop.html) pattern.

The changes made in this PR generally follow the instructions in the [Forwarding refs to HOCs documentation](https://reactjs.org/docs/forwarding-refs.html#forwarding-refs-in-higher-order-components), although there's some additional logic caused by the HOC needing the inner ref, as well (setRef copied from [here](https://github.com/facebook/react/issues/13029#issuecomment-497629971)).

~TODO: Add tests that would fail if the ref isn't forwarded~. Done