### PR TITLE
Lint all source folders

### DIFF
--- a/e2e/00_initial.spec.js
+++ b/e2e/00_initial.spec.js
@@ -17,6 +17,9 @@ describe('Initial Navigation', () => {
   });
 
   it('tracks the initial route', async () => {
-    await rnTestUtil.assertNavigationEvent('Initial', 'Heap_Navigation/INITIAL');
+    await rnTestUtil.assertNavigationEvent(
+      'Initial',
+      'Heap_Navigation/INITIAL'
+    );
   });
 });

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -153,11 +153,19 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it('preserve the same session between track calls', async () => {
-      const findAndroidEvent = nodeUtil.promisify(testUtil.findAndroidEventInRedisRequests);
+      const findAndroidEvent = nodeUtil.promisify(
+        testUtil.findAndroidEventInRedisRequests
+      );
 
       const [[event1], [event2]] = await Promise.all([
-        findAndroidEvent({ envId: '2084764307', event: { custom: { name: 'pressInTestEvent1' } } }),
-        findAndroidEvent({ envId: '2084764307', event: { custom: { name: 'pressInTestEvent2' } } })
+        findAndroidEvent({
+          envId: '2084764307',
+          event: { custom: { name: 'pressInTestEvent1' } },
+        }),
+        findAndroidEvent({
+          envId: '2084764307',
+          event: { custom: { name: 'pressInTestEvent2' } },
+        }),
       ]);
 
       assert(event1.sessionInfo.id).equal(event2.sessionInfo.id);

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -140,14 +140,16 @@ const extendsReactComponent = path => {
   );
 };
 
-const isSwitchNode = (path) => {
+const isSwitchNode = path => {
   // The method we want to instrument:
   // * Is named '_handleChange'
   // * Has a variable declarator parent named 'Switch'
   // * The parent extends 'React.Component'.
   if (
-    !(path.node.left.property &&
-    path.node.left.property.name === '_handleChange')
+    !(
+      path.node.left.property &&
+      path.node.left.property.name === '_handleChange'
+    )
   ) {
     return false;
   }
@@ -161,7 +163,7 @@ const isSwitchNode = (path) => {
   });
 
   return !!parent;
-}
+};
 
 const instrumentSwitchComponent = path => {
   if (instrumentedComponentNodes.has(path)) {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "test": "jest",
     "test-instrumentor": "cd instrumentor && ../node_modules/mocha/bin/mocha -r @babel/register test/ && cd ..",
-    "lint": "./node_modules/prettylint/bin/cli.js \"js/**/*.{js,ts}\"",
+    "lint": "./node_modules/prettylint/bin/cli.js \"{js,e2e,instrumentor/src}/**/*.{js,ts}\"",
     "lint-example": "./node_modules/prettylint/bin/cli.js \"examples/**/*.{js,ts}\"",
     "compile": "./node_modules/typescript/bin/tsc",
     "prepublish": "npm run-script compile"


### PR DESCRIPTION
Currently, our linting commands (and thus CI) only checks the `js/` and `examples/` folders.  As a result, the `instrumentor/` and `e2e/` folders have become unformatted.

Update the `lint` command to also lint `instrumentor/src/` (to avoid the test files) and `e2e/`, and format these folders accordingly.