### PR TITLE
Pin detox version

### DIFF
--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "babel-jest": "23.6.0",
-    "detox": "^12.1.1",
+    "detox": "12.1.1",
     "jest": "23.6.0",
     "metro-react-native-babel-preset": "0.49.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^10.12.19",
     "coffeescript": "^1.12.7",
     "deep-freeze": "0.0.1",
-    "detox": "^12.1.1",
+    "detox": "12.1.1",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "jest": "^24.0.0",


### PR DESCRIPTION
There seems to be a bug in later versions of detox that are causing android tests to hang when I run locally.  Pin detox to a specific version instead of using `^`.