### PR TITLE
[HEAP-8753] Fix null reference issue in react nav HOC

### DIFF
--- a/examples/TestDriver/App.js
+++ b/examples/TestDriver/App.js
@@ -6,6 +6,12 @@ import TopNavigator from './src/topNavigator';
 import NavigationService from './src/navigatorService';
 
 export default class App extends React.Component {
+  componentDidMount() {
+    setTimeout(() => {
+      console.log('Forcing update of react nav HOC via setState().');
+      this.setState({});
+    }, 3000);
+  }
   render() {
     return (
       <Provider store={store}>

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -47,7 +47,11 @@ export const withReactNavigationAutotrack = track => AppContainer => {
         <AppContainer
           ref={bailOnError(navigatorRef => {
             this.setRef(forwardedRef, navigatorRef);
-            if (this.topLevelNavigator !== navigatorRef) {
+            // Only update the 'topLevelNavigator' if the new nav ref is different and non-null.
+            if (
+              this.topLevelNavigator !== navigatorRef &&
+              navigatorRef !== null
+            ) {
               console.log(
                 'Heap: React Navigation is instrumented for autocapture.'
               );


### PR DESCRIPTION
Some customers were experiencing a `Cannot read property 'nav' of null` error with the react nav HOC.  This is most likely caused by some sort of re-rendering or ref update of some top-level components, including the navigation container wrapped by our HOC.

I have not repro'd this issue via a real-life use case, but doing `this.setState()` seems to force the ref update.  Confirmed that these changes resolve the issue for this specific case.

Note: while this example led to the component ref getting updated to the same value as the previous ref (i.e. getting updated from `ref1` -> `null` -> `ref1`), it's possible that some cases of ref updating may be due to actually different refs (e.g. `ref1` -> `null` -> `ref2`).  If this were to be the case, this would lead to potentially duplicated `Navigation/INITIAL` nav events.  However, unless someone surfaces this as a real issue, addressing this possibility is likely YAGNI.