### PR TITLE
[HEAP-9951] Capture screen name props for autocaptured events

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -76,7 +76,8 @@ describe('Basic React Native and Interaction Support', () => {
         event => {
           return !(
             _.includes(event.k, 'eventProp1') ||
-            _.includes(event.k, 'eventProp2')
+            _.includes(event.k, 'eventProp2') ||
+            _.includes(event.k, 'path')
           );
         }
       );
@@ -88,7 +89,8 @@ describe('Basic React Native and Interaction Support', () => {
         event => {
           return (
             _.includes(event.k, 'eventProp1') &&
-            _.includes(event.k, 'eventProp2')
+            _.includes(event.k, 'eventProp2') &&
+            !_.includes(event.k, 'path')
           );
         }
       );
@@ -100,7 +102,8 @@ describe('Basic React Native and Interaction Support', () => {
         event => {
           return (
             !_.includes(event.k, 'eventProp1') &&
-            _.includes(event.k, 'eventProp2')
+            _.includes(event.k, 'eventProp2') &&
+            !_.includes(event.k, 'path')
           );
         }
       );
@@ -112,7 +115,8 @@ describe('Basic React Native and Interaction Support', () => {
         event => {
           return !(
             _.includes(event.k, 'eventProp1') ||
-            _.includes(event.k, 'eventProp2')
+            _.includes(event.k, 'eventProp2') ||
+            _.includes(event.k, 'path')
           );
         }
       );
@@ -159,7 +163,8 @@ describe('Basic React Native and Interaction Support', () => {
         event => {
           return (
             !_.has(event.properties, 'eventProp1') &&
-            !_.has(event.properties, 'eventProp2')
+            !_.has(event.properties, 'eventProp2') &&
+            !_.has(event.properties, 'path')
           );
         }
       );
@@ -193,7 +198,8 @@ describe('Basic React Native and Interaction Support', () => {
         event => {
           return (
             _.has(event.properties, 'eventProp1') &&
-            _.has(event.properties, 'eventProp2')
+            _.has(event.properties, 'eventProp2') &&
+            !_.has(event.properties, 'path')
           );
         }
       );
@@ -208,7 +214,8 @@ describe('Basic React Native and Interaction Support', () => {
         event => {
           return (
             !_.has(event.properties, 'eventProp1') &&
-            _.has(event.properties, 'eventProp2')
+            _.has(event.properties, 'eventProp2') &&
+            !_.has(event.properties, 'path')
           );
         }
       );
@@ -223,7 +230,8 @@ describe('Basic React Native and Interaction Support', () => {
         event => {
           return (
             !_.has(event.properties, 'eventProp1') &&
-            !_.has(event.properties, 'eventProp2')
+            !_.has(event.properties, 'eventProp2') &&
+            !_.has(event.properties, 'path')
           );
         }
       );
@@ -266,6 +274,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
         touchableHierarchy: expectedHierarchy,
         targetText: expectedTargetText,
+        screenName: 'Basics',
+        path: 'Basics',
       });
     });
 
@@ -276,6 +286,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
         touchableHierarchy: expectedHierarchy,
         targetText: expectedTargetText,
+        screenName: 'Basics',
+        path: 'Basics',
       });
     });
 
@@ -286,6 +298,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
         touchableHierarchy: expectedHierarchy,
         targetText: expectedTargetText,
+        screenName: 'Basics',
+        path: 'Basics',
       });
     });
 
@@ -296,6 +310,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
         touchableHierarchy: expectedHierarchy,
         targetText: expectedTargetText,
+        screenName: 'Basics',
+        path: 'Basics',
       });
     });
 
@@ -304,6 +320,8 @@ describe('Basic React Native and Interaction Support', () => {
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|Switch;[testID=switch];|';
       await rnTestUtil.assertAutotrackHierarchy('_handleChange', {
         touchableHierarchy: expectedHierarchy,
+        screenName: 'Basics',
+        path: 'Basics',
       });
     });
 
@@ -312,6 +330,8 @@ describe('Basic React Native and Interaction Support', () => {
         'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|StyledComponent;[testID=nbSwitch];|Switch;[testID=nbSwitch];|Switch;[testID=nbSwitch];|';
       await rnTestUtil.assertAutotrackHierarchy('_handleChange', {
         touchableHierarchy: expectedHierarchy,
+        screenName: 'Basics',
+        path: 'Basics',
       });
     });
 
@@ -321,6 +341,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('scrollViewPage', {
         touchableHierarchy: expectedHierarchy,
         pageIndex: '1',
+        screenName: 'Basics',
+        path: 'Basics',
       });
     });
   });

--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -72,6 +72,23 @@ describe('Navigation', () => {
       );
     });
 
+    it('tracks events with screen name props', async () => {
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        screenName: 'Base',
+        path: 'Nav::MainStack::Base',
+      });
+
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        screenName: 'StackCard',
+        path: 'Nav::MainStack::StackCard',
+      });
+
+      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+        screenName: 'ModalStack',
+        path: 'Nav::ModalStack',
+      });
+    });
+
     it("doesn't crash when ref is used for navigation without navigation prop", async () => {
       await element(by.id('navigate_without_prop')).tap();
       // Check that app doesn't crash by asserting the button is still visible.

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -18,6 +18,8 @@ interface Component extends ReactComponent {
 interface AutotrackProps {
   touchableHierarchy: string;
   targetText?: string;
+  path?: string;
+  screenName?: string;
 }
 
 interface HeapIgnoreProps {

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -5,6 +5,7 @@ import { Fiber as FiberNode } from 'react-reconciler';
 import { extractProps } from '../util/extractProps';
 import { BASE_HEAP_IGNORE_PROPS, getNextHeapIgnoreProps } from './heapIgnore';
 import { builtinPropExtractorConfig } from '../propExtractorConfig';
+import NavigationUtil from '../util/navigationUtil';
 
 // The type definition of 'Component' from '@types/react' doesn't include the internal
 // '_reactInternalFiber' property, so create our own 'Component' type that includes this prop.
@@ -67,8 +68,11 @@ export const getBaseComponentProps: (
     targetText = '';
   }
 
+  const screenProps = NavigationUtil.getScreenPropsForCurrentRoute();
+
   const autotrackProps: AutotrackProps = {
     touchableHierarchy: hierarchy,
+    ...screenProps,
   };
 
   if (targetText !== '') {

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -48,6 +48,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
         <AppContainer
           ref={bailOnError(navigatorRef => {
             this.setRef(forwardedRef, navigatorRef);
+            // Update the NavigationUtil's nav reference to the updated ref.
             NavigationUtil.setNavigationRef(navigatorRef);
             // Only update the 'topLevelNavigator' if the new nav ref is different and non-null.
             if (

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { bail, bailOnError } from '../util/bailer';
+import NavigationUtil from '../util/navigationUtil';
 
 const EVENT_TYPE = 'reactNavigationScreenview';
 
@@ -21,7 +22,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
     }
 
     trackInitialRoute() {
-      const initialPageviewPath = getActiveRouteName(
+      const initialPageviewPath = NavigationUtil.getActiveRouteName(
         this.topLevelNavigator.state.nav
       );
 
@@ -60,10 +61,10 @@ export const withReactNavigationAutotrack = track => AppContainer => {
             }
           })}
           onNavigationStateChange={bailOnError((prev, next, action) => {
-            const prevScreenRoute = getActiveRouteName(prev);
-            const nextScreenRoute = getActiveRouteName(next);
+            const prevScreenRoute = NavigationUtil.getActiveRouteName(prev);
+            const nextScreenRoute = NavigationUtil.getActiveRouteName(next);
             if (prevScreenRoute !== nextScreenRoute) {
-              const currentScreen = getActiveRouteName(next);
+              const currentScreen = NavigationUtil.getActiveRouteName(next);
               track(EVENT_TYPE, {
                 path: currentScreen,
                 type: action.type,
@@ -81,17 +82,4 @@ export const withReactNavigationAutotrack = track => AppContainer => {
   return React.forwardRef((props, ref) => {
     return <HeapNavigationWrapper {...props} forwardedRef={ref} />;
   });
-};
-
-const getActiveRouteName = navigationState => {
-  if (!navigationState) {
-    return null;
-  }
-  const route = navigationState.routes[navigationState.index];
-  // dive into nested navigators
-  if (route.routes) {
-    return `${route.routeName}::${getActiveRouteName(route)}`;
-  }
-
-  return route.routeName;
 };

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -22,7 +22,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
     }
 
     trackInitialRoute() {
-      const initialPageviewPath = NavigationUtil.getActiveRouteName(
+      const { path: initialPageviewPath } = NavigationUtil.getActiveRouteProps(
         this.topLevelNavigator.state.nav
       );
 
@@ -48,6 +48,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
         <AppContainer
           ref={bailOnError(navigatorRef => {
             this.setRef(forwardedRef, navigatorRef);
+            NavigationUtil.setNavigationRef(navigatorRef);
             // Only update the 'topLevelNavigator' if the new nav ref is different and non-null.
             if (
               this.topLevelNavigator !== navigatorRef &&
@@ -61,12 +62,15 @@ export const withReactNavigationAutotrack = track => AppContainer => {
             }
           })}
           onNavigationStateChange={bailOnError((prev, next, action) => {
-            const prevScreenRoute = NavigationUtil.getActiveRouteName(prev);
-            const nextScreenRoute = NavigationUtil.getActiveRouteName(next);
+            const {
+              path: prevScreenRoute,
+            } = NavigationUtil.getActiveRouteProps(prev);
+            const {
+              path: nextScreenRoute,
+            } = NavigationUtil.getActiveRouteProps(next);
             if (prevScreenRoute !== nextScreenRoute) {
-              const currentScreen = NavigationUtil.getActiveRouteName(next);
               track(EVENT_TYPE, {
-                path: currentScreen,
+                path: nextScreenRoute,
                 type: action.type,
               });
             }

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -29,20 +29,24 @@ export default class NavigationUtil {
   static getActiveRouteProps(
     navigationState: any
   ): { path: string; screenName: string } {
+    const paths = this.getActiveRouteNames(navigationState);
+    return {
+      path: paths.join('::'),
+      screenName: paths[paths.length - 1] };
+  }
+
+  // Returns an array of route names, with the root name first, and the most nested name last.
+  private static getActiveRouteNames(
+    navigationState: any
+  ): Array<string> {
     const route = navigationState.routes[navigationState.index];
 
     // Dive into nested navigators.
     if (route.routes) {
-      const { path, screenName } = this.getActiveRouteProps(route);
-      return {
-        path: `${route.routeName}::${path}`,
-        screenName: screenName,
-      };
+      const paths = this.getActiveRouteNames(route);
+      return [ route.routeName ].concat(paths);
     }
 
-    return {
-      path: route.routeName,
-      screenName: route.routeName,
-    };
+    return [ route.routeName ];
   }
 }

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -32,21 +32,20 @@ export default class NavigationUtil {
     const paths = this.getActiveRouteNames(navigationState);
     return {
       path: paths.join('::'),
-      screenName: paths[paths.length - 1] };
+      screenName: paths[paths.length - 1],
+    };
   }
 
   // Returns an array of route names, with the root name first, and the most nested name last.
-  private static getActiveRouteNames(
-    navigationState: any
-  ): Array<string> {
+  private static getActiveRouteNames(navigationState: any): Array<string> {
     const route = navigationState.routes[navigationState.index];
 
     // Dive into nested navigators.
     if (route.routes) {
       const paths = this.getActiveRouteNames(route);
-      return [ route.routeName ].concat(paths);
+      return [route.routeName].concat(paths);
     }
 
-    return [ route.routeName ];
+    return [route.routeName];
   }
 }

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -1,0 +1,14 @@
+export default class NavigationUtil {
+  static getActiveRouteName(navigationState: any): any {
+    if (!navigationState) {
+      return null;
+    }
+    const route = navigationState.routes[navigationState.index];
+    // dive into nested navigators
+    if (route.routes) {
+      return `${route.routeName}::${this.getActiveRouteName(route)}`;
+    }
+
+    return route.routeName;
+  };
+}

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -1,14 +1,48 @@
 export default class NavigationUtil {
-  static getActiveRouteName(navigationState: any): any {
-    if (!navigationState) {
+  // :TODO: (jmtaber129): Add typing for this ref.
+  private static heapNavRef: any;
+
+  static setNavigationRef(ref: any): void {
+    this.heapNavRef = ref;
+  }
+
+  static getScreenPropsForCurrentRoute(): {
+    path: string;
+    screenName: string;
+  } | null {
+    if (
+      !(this.heapNavRef && this.heapNavRef.state && this.heapNavRef.state.nav)
+    ) {
       return null;
     }
-    const route = navigationState.routes[navigationState.index];
-    // dive into nested navigators
-    if (route.routes) {
-      return `${route.routeName}::${this.getActiveRouteName(route)}`;
+
+    const routeProps = this.getActiveRouteProps(this.heapNavRef.state.nav);
+
+    if (routeProps) {
+      return routeProps;
     }
 
-    return route.routeName;
-  };
+    return null;
+  }
+
+  // :TODO: (jmtaber129): Add type for navigationState.
+  static getActiveRouteProps(
+    navigationState: any
+  ): { path: string; screenName: string } {
+    const route = navigationState.routes[navigationState.index];
+
+    // Dive into nested navigators.
+    if (route.routes) {
+      const { path, screenName } = this.getActiveRouteProps(route);
+      return {
+        path: `${route.routeName}::${path}`,
+        screenName: screenName,
+      };
+    }
+
+    return {
+      path: route.routeName,
+      screenName: route.routeName,
+    };
+  }
 }


### PR DESCRIPTION
This adds `path` and `screenName` props to all autocaptured events (e.g. `touchableHandlePress`, etc.), where `path` is the full path of the current screen route (e.g. `Nav::MainStack::Base`), and `screenName` is the individual name of the current screen route (e.g. `Base`).

This does *not* include these props on custom tracked events.