### PR TITLE
[HEAP-10061] Fix scrollview `this` issue

### DIFF
--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -65,7 +65,7 @@ const instrumentTouchables = path => {
 
     const replacementFunc = getOriginalFunctionReplacement(
       path.node.value, // originalFunctionExpression
-      'this', // thisIdentifier
+      t.identifier('this'), // thisIdentifier
       'autotrackPress', // autotrackMethodName
       path.node.key.name // eventType
     );
@@ -108,7 +108,7 @@ const instrumentScrollView = path => {
 
     const replacementFunc = getOriginalFunctionReplacement(
       path.node.value, // originalFunctionExpression
-      '_this', // thisIdentifier
+      t.thisExpression(), // thisIdentifier
       'autocaptureScrollView', // autotrackMethodName
       'scrollViewPage' // eventType
     );
@@ -128,7 +128,7 @@ const getOriginalFunctionReplacement = (
   );
 
   const calledFunction = t.callExpression(callOriginalFunctionExpression, [
-    t.identifier(thisIdentifier),
+    thisIdentifier,
     t.identifier('e'),
   ]);
 
@@ -139,7 +139,7 @@ const getOriginalFunctionReplacement = (
     t.memberExpression(t.identifier('Heap'), t.identifier(autotrackMethodName)),
     [
       t.stringLiteral(eventType),
-      t.identifier(thisIdentifier),
+      thisIdentifier,
       t.identifier('e'),
     ]
   );
@@ -223,7 +223,7 @@ const instrumentSwitchComponent = path => {
   const originalFunctionExpression = path.node.right;
   const replacementFunc = getOriginalFunctionReplacement(
     originalFunctionExpression, // originalFunctionExpression
-    '_this', // thisIdentifier
+    t.thisExpression(), // thisIdentifier
     'autotrackSwitchChange', // autotrackMethodName
     path.node.left.property.name // eventType
   );

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -137,11 +137,7 @@ const getOriginalFunctionReplacement = (
   // 'Heap.autotrackPress(<press type>, this, e)'.
   const autotrackExpression = t.callExpression(
     t.memberExpression(t.identifier('Heap'), t.identifier(autotrackMethodName)),
-    [
-      t.stringLiteral(eventType),
-      thisExpression,
-      t.identifier('e'),
-    ]
+    [t.stringLiteral(eventType), thisExpression, t.identifier('e')]
   );
 
   // Function body for tracking the Heap event, then calling the original function.

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -65,7 +65,7 @@ const instrumentTouchables = path => {
 
     const replacementFunc = getOriginalFunctionReplacement(
       path.node.value, // originalFunctionExpression
-      t.identifier('this'), // thisIdentifier
+      t.identifier('this'), // thisExpression
       'autotrackPress', // autotrackMethodName
       path.node.key.name // eventType
     );
@@ -108,7 +108,7 @@ const instrumentScrollView = path => {
 
     const replacementFunc = getOriginalFunctionReplacement(
       path.node.value, // originalFunctionExpression
-      t.thisExpression(), // thisIdentifier
+      t.thisExpression(), // thisExpression
       'autocaptureScrollView', // autotrackMethodName
       'scrollViewPage' // eventType
     );
@@ -118,7 +118,7 @@ const instrumentScrollView = path => {
 
 const getOriginalFunctionReplacement = (
   originalFunctionExpression,
-  thisIdentifier,
+  thisExpression,
   autotrackMethodName,
   eventType
 ) => {
@@ -128,7 +128,7 @@ const getOriginalFunctionReplacement = (
   );
 
   const calledFunction = t.callExpression(callOriginalFunctionExpression, [
-    thisIdentifier,
+    thisExpression,
     t.identifier('e'),
   ]);
 
@@ -139,7 +139,7 @@ const getOriginalFunctionReplacement = (
     t.memberExpression(t.identifier('Heap'), t.identifier(autotrackMethodName)),
     [
       t.stringLiteral(eventType),
-      thisIdentifier,
+      thisExpression,
       t.identifier('e'),
     ]
   );
@@ -223,7 +223,7 @@ const instrumentSwitchComponent = path => {
   const originalFunctionExpression = path.node.right;
   const replacementFunc = getOriginalFunctionReplacement(
     originalFunctionExpression, // originalFunctionExpression
-    t.identifier('_this'), // thisIdentifier
+    t.identifier('_this'), // thisExpression
     'autotrackSwitchChange', // autotrackMethodName
     path.node.left.property.name // eventType
   );

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -223,7 +223,7 @@ const instrumentSwitchComponent = path => {
   const originalFunctionExpression = path.node.right;
   const replacementFunc = getOriginalFunctionReplacement(
     originalFunctionExpression, // originalFunctionExpression
-    t.thisExpression(), // thisIdentifier
+    t.identifier('_this'), // thisIdentifier
     'autotrackSwitchChange', // autotrackMethodName
     path.node.left.property.name // eventType
   );

--- a/instrumentor/test/fixtures/is-scroll-view-createreactclass/output.js
+++ b/instrumentor/test/fixtures/is-scroll-view-createreactclass/output.js
@@ -5,7 +5,7 @@ var _objectSpread2 = _interopRequireDefault(require("@babel/runtime/helpers/obje
 var ScrollView = createReactClass({
   displayName: "ScrollView",
   render: function render() {
-    var _this2 = this;
+    var _this = this;
 
     var props = (0, _objectSpread2.default)({}, this.props, {
       onMomentumScrollEnd: function onMomentumScrollEnd(e) {
@@ -13,7 +13,7 @@ var ScrollView = createReactClass({
 
         Heap.autocaptureScrollView("scrollViewPage", _this, e);
 
-        _this2.scrollResponderHandleMomentumScrollEnd.call(_this, e);
+        _this.scrollResponderHandleMomentumScrollEnd.call(_this, e);
       }
     });
     var decelerationRate = this.props.decelerationRate;

--- a/instrumentor/test/fixtures/is-scroll-view-extends-component/output.js
+++ b/instrumentor/test/fixtures/is-scroll-view-extends-component/output.js
@@ -42,9 +42,9 @@ var ScrollView = function (_React$Component) {
         onMomentumScrollEnd: function onMomentumScrollEnd(e) {
           var Heap = require('@heap/react-native-heap').default;
 
-          Heap.autocaptureScrollView("scrollViewPage", _this, e);
+          Heap.autocaptureScrollView("scrollViewPage", _this2, e);
 
-          _this2._scrollResponder.scrollResponderHandleMomentumScrollEnd.call(_this, e);
+          _this2._scrollResponder.scrollResponderHandleMomentumScrollEnd.call(_this2, e);
         }
       });
       var decelerationRate = this.props.decelerationRate;


### PR DESCRIPTION
~Leaving this as a draft until I confirm the most recent changes work on both RN 0.57.5 and RN 0.60.4, but otherwise ready for review~.  I haven't been able to get RN 0.60.4 to build Android on the test app, but I got an upgraded iOS build to a state in which unit+e2e tests pass on RN 0.60.4.  Because this was an issue with the babel plugin (not native code), I think it's reasonable to go ahead and merge.

On newer versions of react native (after the `ScrollView` component was switch from using a mixin and `createReactClass` to extending `React.Component`), the referenced `this` is incorrect, and causes errors upon `onMomentumScrollEnd()`.

Change the `ScrollView` instrumentation to use `t.thisExpression()` instead of `t.identifier('_this')`.
TODO: look into using `t.thisExpression()` for other instrumentations (this doesn't seem to work for these out-of-the-box).

Fixes https://github.com/heap/react-native-heap/issues/119