### PR TITLE
Upgrade iOS lib to 6.2.1, bump RN lib version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ __BEGIN_UNRELEASED__
 ### Security
 __END_UNRELEASED__
 
+## [0.7.0] - 2019-08-14
+
+### Fixed
+- Upgraded vendored iOS Heap library to 6.2.1, which fixed an issue where user IDs were not being reused across sessions in some cases.
+
 ## [0.7.0] - 2019-08-07
 
 ### Added

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - glog (0.3.5)
   - React (0.57.5):
     - React/Core (= 0.57.5)
-  - react-native-heap (0.7.0):
+  - react-native-heap (0.7.1):
     - React
   - React/Core (0.57.5):
     - yoga (= 0.57.5.React)
@@ -105,11 +105,11 @@ SPEC CHECKSUMS:
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
   glog: e8acf0ebbf99759d3ff18c86c292a5898282dcde
-  React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
-  react-native-heap: 4a472f188a82a8250d87144325c8c569ef6d5b1c
-  RNGestureHandler: 7ccf2f3f60458e084f9ada01fbaf610f6fef073c
-  yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
+  React: 01aa04500b2957c2767e1dff9fe12e09444a467c
+  react-native-heap: 32f264fa72b26cb784ab42cd7f7d663a7151e0cc
+  RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
+  yoga: a5c0ba30ebe82c13612b4c9301ad29708b8978dc
 
 PODFILE CHECKSUM: 94963ca9da08a6f38a9019eb8da64ec0f890b712
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/examples/TestDriver/ios/TestDriver.xcodeproj/project.pbxproj
+++ b/examples/TestDriver/ios/TestDriver.xcodeproj/project.pbxproj
@@ -358,7 +358,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-resources.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-TestDriver/Pods-TestDriver-resources.sh",
 				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-heap/HeapSettings.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -369,7 +369,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestDriver/Pods-TestDriver-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		2853483F96FDDC922D462B77 /* [CP] Check Pods Manifest.lock */ = {
@@ -416,7 +416,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/DoubleConversion/DoubleConversion.framework",
 				"${BUILT_PRODUCTS_DIR}/Folly/folly.framework",
 				"${BUILT_PRODUCTS_DIR}/RNGestureHandler/RNGestureHandler.framework",
@@ -437,7 +437,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E5F03DDBB7275D0F8105EA52 /* [CP] Check Pods Manifest.lock */ = {

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "./preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.7.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.7.1.tgz",
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",

--- a/ios/Vendor/Heap.h
+++ b/ios/Vendor/Heap.h
@@ -1,6 +1,6 @@
 //
 //  Heap.h
-//  Version 6.2.0
+//  Version 6.2.1
 //  Copyright (c) 2014 Heap Inc. All rights reserved.
 //
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
The libHeap v6.2.0 that had previously been included with this package had a nasty bug where user IDs would not be reused across sessions (more or less).  This PR updates the embedded lib to 6.2.1, and bumps the version of this lib to 0.7.1