### PR TITLE
Grab bag of test improvements

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -17,28 +17,19 @@ const doTestActions = async () => {
   await element(by.id('aep')).tap();
   await element(by.id('track2')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await element(by.id('removeProp')).tap();
   await element(by.id('track3')).tap();
   await element(by.id('clearProps')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await element(by.id('track4')).tap();
   await element(by.id('aup')).tap();
   await element(by.id('identify')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await element(by.id('touchableOpacityText')).tap();
   await element(by.id('touchableHighlightText')).tap();
@@ -48,28 +39,19 @@ const doTestActions = async () => {
     await element(by.id('touchableNativeFeedbackText')).tap();
   }
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await element(by.id('switch')).tap();
   await element(by.id('nbSwitch')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await element(by.id('textInput')).typeText('foo ');
   await element(by.id('textInput')).tapReturnKey();
 
   await element(by.id('resetIdentity')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await waitFor(element(by.id('basicsSentinel')))
     .toBeVisible()

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -49,6 +49,7 @@ const doTestActions = async () => {
   await element(by.id('textInput')).typeText('foo ');
   await element(by.id('textInput')).tapReturnKey();
 
+  await expect(element(by.id('resetIdentity'))).toBeVisible();
   await element(by.id('resetIdentity')).tap();
 
   await rnTestUtil.waitIfIos();

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -64,16 +64,13 @@ const doTestActions = async () => {
 };
 
 describe('Basic React Native and Interaction Support', () => {
-  before(done => {
-    db.orm.connection.sharedRedis().flushall(done);
+  before(async () => {
+    await rnTestUtil.flushAllRedis();
+    await doTestActions();
+    await rnTestUtil.pollForSentinel('Basics');
   });
 
   describe(':ios: Bridge API', () => {
-    before(async () => {
-      await doTestActions();
-      await rnTestUtil.pollForSentinel('Basics');
-    });
-
     it('should call first track', async () => {
       await rnTestUtil.assertIosPixel(
         { a: '2084764307', t: 'pressInTestEvent1' },
@@ -181,11 +178,6 @@ describe('Basic React Native and Interaction Support', () => {
   });
 
   describe(':android: Bridge API', () => {
-    before(async () => {
-      await doTestActions();
-      await rnTestUtil.pollForSentinel('Basics');
-    });
-
     it('should call first track', async () => {
       await rnTestUtil.assertAndroidEvent(
         {

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -6,6 +6,8 @@ nodeUtil = require('util');
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
+const BASICS_PAGE_TOP_HIERARCHY = 'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|';
+
 const doTestActions = async () => {
   // Open the Basics tab in the tab navigator.
   await element(by.id('Basics')).tap();
@@ -343,8 +345,7 @@ describe('Basic React Native and Interaction Support', () => {
 
   describe('Autotrack', () => {
     it("should autotrack 'TouchableOpacity's", async () => {
-      const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|TouchableOpacity;[testID=touchableOpacityText];|';
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableOpacity;[testID=touchableOpacityText];|`;
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
         touchableHierarchy: expectedHierarchy,
@@ -355,8 +356,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it("should autotrack 'TouchableHighlight's", async () => {
-      const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|TouchableHighlight;[testID=touchableHighlightText];|';
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableHighlight;[testID=touchableHighlightText];|`;
       const expectedTargetText = 'Touchable Highlight';
       await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
         touchableHierarchy: expectedHierarchy,
@@ -367,8 +367,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
-      const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|';
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|`;
       const expectedTargetText = 'Touchable Without Feedback';
       await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
         touchableHierarchy: expectedHierarchy,
@@ -379,8 +378,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
-      const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|';
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|`;
       const expectedTargetText = 'Touchable Native Feedback';
       await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
         touchableHierarchy: expectedHierarchy,
@@ -391,8 +389,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it("should autotrack 'Switch's", async () => {
-      const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|Switch;[testID=switch];|';
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}Switch;[testID=switch];|`;
       await rnTestUtil.assertAutotrackHierarchy('_handleChange', {
         touchableHierarchy: expectedHierarchy,
         screenName: 'Basics',
@@ -401,8 +398,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it("should autotrack NativeBase 'Switch's", async () => {
-      const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|StyledComponent;[testID=nbSwitch];|Switch;[testID=nbSwitch];|Switch;[testID=nbSwitch];|';
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}StyledComponent;[testID=nbSwitch];|Switch;[testID=nbSwitch];|Switch;[testID=nbSwitch];|`;
       await rnTestUtil.assertAutotrackHierarchy('_handleChange', {
         touchableHierarchy: expectedHierarchy,
         screenName: 'Basics',
@@ -411,8 +407,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it('should autotrack ScrollView paging', async () => {
-      const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|FlatList;[testID=scrollView];|VirtualizedList;[testID=scrollView];|ScrollView;[testID=scrollView];|';
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}FlatList;[testID=scrollView];|VirtualizedList;[testID=scrollView];|ScrollView;[testID=scrollView];|`;
       await rnTestUtil.assertAutotrackHierarchy('scrollViewPage', {
         touchableHierarchy: expectedHierarchy,
         pageIndex: '1',
@@ -422,8 +417,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it('should autotrack TextInput edits', async () => {
-      const expectedHierarchy =
-        'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|MyTextInput;[testID=textInput];|TextInput;[testID=textInput];|';
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}MyTextInput;[testID=textInput];|TextInput;[testID=textInput];|`;
       await rnTestUtil.assertAutotrackHierarchy('textEdit', {
         touchableHierarchy: expectedHierarchy,
         placeholderText: 'foo placeholder',

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -6,7 +6,8 @@ nodeUtil = require('util');
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
-const BASICS_PAGE_TOP_HIERARCHY = 'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|';
+const BASICS_PAGE_TOP_HIERARCHY =
+  'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|';
 
 const doTestActions = async () => {
   // Open the Basics tab in the tab navigator.

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -16,19 +16,14 @@ const doTestActions = async () => {
   await element(by.id('totallyIgnored')).tap();
   await element(by.id('totallyIgnoredHoc')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await element(by.id('allowedInteraction')).tap();
   await element(by.id('allowedInnerHierarchy')).tap();
   await element(by.id('allowedAllProps')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
+
   await element(by.id('allowedTargetText')).tap();
   await element(by.id('ignoredTargetText')).tap();
 

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -31,11 +31,8 @@ const doTestActions = async () => {
 };
 
 describe('HeapIgnore', () => {
-  before(done => {
-    db.orm.connection.sharedRedis().flushall(done);
-  });
-
   before(async () => {
+    await rnTestUtil.flushAllRedis();
     await doTestActions();
     await rnTestUtil.pollForSentinel('HeapIgnore');
   });

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -6,7 +6,8 @@ nodeUtil = require('util');
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
-const HEAPIGNORE_PAGE_TOP_HIERARCHY = 'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|';
+const HEAPIGNORE_PAGE_TOP_HIERARCHY =
+  'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|';
 
 const doTestActions = async () => {
   // Open the HeapIgnore tab in the tab navigator.

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -6,6 +6,8 @@ nodeUtil = require('util');
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
+const HEAPIGNORE_PAGE_TOP_HIERARCHY = 'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|';
+
 const doTestActions = async () => {
   // Open the HeapIgnore tab in the tab navigator.
   await element(by.id('HeapIgnore')).tap();
@@ -57,24 +59,21 @@ describe('HeapIgnore', () => {
   });
 
   it('should ignore the inner hierarchy', async () => {
-    const expectedHierarchy =
-      'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|HeapIgnore;|';
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|`;
     await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
       touchableHierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore props and target text', async () => {
-    const expectedHierarchy =
-      'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|HeapIgnore;|TouchableOpacity;|';
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|TouchableOpacity;|`;
     await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
       touchableHierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore props', async () => {
-    const expectedHierarchy =
-      'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|HeapIgnore;|TouchableOpacity;|';
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|TouchableOpacity;|`;
     await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
       touchableHierarchy: expectedHierarchy,
       targetText: 'Foobar',
@@ -82,8 +81,7 @@ describe('HeapIgnore', () => {
   });
 
   it('should ignore target text', async () => {
-    const expectedHierarchy =
-      'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|HeapIgnoreTargetText;|HeapIgnore;|TouchableOpacity;[testID=ignoredTargetText];|';
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnoreTargetText;|HeapIgnore;|TouchableOpacity;[testID=ignoredTargetText];|`;
     await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
       touchableHierarchy: expectedHierarchy,
     });

--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -20,10 +20,7 @@ const doTestActions = async () => {
   await element(by.id('pop1')).tap();
   await delay();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await expect(element(by.id('navigate_modal'))).toBeVisible();
   await element(by.id('navigate_modal')).tap();

--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -33,12 +33,9 @@ const doTestActions = async () => {
 };
 
 describe('Navigation', () => {
-  before(done => {
-    db.orm.connection.sharedRedis().flushall(done);
-  });
-
   describe('React Navigation autotrack', () => {
     before(async () => {
+      await rnTestUtil.flushAllRedis();
       await doTestActions();
       await rnTestUtil.pollForSentinel('Nav');
     });

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -8,6 +8,8 @@ rnTestUtil = require('./rnTestUtilities');
 const IOS_BUTTON_SUFFIX = 'TouchableOpacity;';
 const ANDROID_BUTTON_SUFFIX = 'TouchableNativeFeedback;';
 
+const PROPEXTRACTION_PAGE_TOP_HIERARCHY = 'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|';
+
 const doTestActions = async () => {
   // Open the PropExtraction tab in the tab navigator.
   await element(by.id('PropExtraction')).tap();
@@ -52,7 +54,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with class components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|Container1;[custom1=customProp1];|Button;[testID=button1];[title=testButtonTitle1];|${buttonSuffix}[testID=button1];|`;
+      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}Container1;[custom1=customProp1];|Button;[testID=button1];[title=testButtonTitle1];|${buttonSuffix}[testID=button1];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle1'
@@ -64,7 +66,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with stateless components', async () => {
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|Container2;[custom2=customProp2];|Button;[testID=button2];[title=testButtonTitle2];|${buttonSuffix}[testID=button2];|`;
+      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}Container2;[custom2=customProp2];|Button;[testID=button2];[title=testButtonTitle2];|${buttonSuffix}[testID=button2];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle2'
@@ -78,7 +80,7 @@ describe('Property Extraction in Hierarchies', () => {
     it('properly excludes properties', async () => {
       // The important thing for this test is that the first mention of 'Button' does NOT include the title property.
       // This is because the first one is a custom class that specifically excludes (while the second one is the built-in Button.)
-      const expectedHierarchy = `AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|Button;|Button;[testID=button3];[title=testButtonTitle3];|${buttonSuffix}[testID=button3];|`;
+      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}Button;|Button;[testID=button3];[title=testButtonTitle3];|${buttonSuffix}[testID=button3];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle3'

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -14,19 +14,13 @@ const doTestActions = async () => {
   // Open the PropExtraction tab in the tab navigator.
   await element(by.id('PropExtraction')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await expect(element(by.id('button1'))).toBeVisible();
   await element(by.id('button1')).tap();
   await element(by.id('button2')).tap();
 
-  // :HACK: Break up long URL.
-  // :TODO: Remove once pixel endpoint is handling larger events again.
-  console.log('Waiting 15s to flush iOS events.');
-  await new Promise(resolve => setTimeout(resolve, 15000));
+  await rnTestUtil.waitIfIos();
 
   await element(by.id('button3')).tap();
 

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -37,12 +37,9 @@ describe('Property Extraction in Hierarchies', () => {
         : ANDROID_BUTTON_SUFFIX;
   });
 
-  before(done => {
-    db.orm.connection.sharedRedis().flushall(done);
-  });
-
   describe('The property extractor', () => {
     before(async () => {
+      await rnTestUtil.flushAllRedis();
       await doTestActions();
       await rnTestUtil.pollForSentinel('PropExtraction');
     });

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -8,7 +8,8 @@ rnTestUtil = require('./rnTestUtilities');
 const IOS_BUTTON_SUFFIX = 'TouchableOpacity;';
 const ANDROID_BUTTON_SUFFIX = 'TouchableNativeFeedback;';
 
-const PROPEXTRACTION_PAGE_TOP_HIERARCHY = 'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|';
+const PROPEXTRACTION_PAGE_TOP_HIERARCHY =
+  'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|';
 
 const doTestActions = async () => {
   // Open the PropExtraction tab in the tab navigator.

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -7,6 +7,15 @@ testUtil = require('../../heap/test/util');
 
 const HEAP_ENV_ID = '2084764307';
 
+const waitIfIos = async () => {
+  if (device.getPlatform() === 'ios') {
+    // :HACK: Break up long URL.
+    // :TODO: Remove once pixel endpoint is handling larger events again.
+    console.log('Waiting 15s to flush iOS events.');
+    await new Promise(resolve => setTimeout(resolve, 15000));
+  }
+}
+
 const assertEvent = (err, res, check) => {
   assert.not.exist(err);
   assert(res.length).not.equal(0);
@@ -198,4 +207,5 @@ module.exports = {
   assertAutotrackHierarchy,
   assertNavigationEvent,
   pollForSentinel,
+  waitIfIos,
 };

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -1,6 +1,7 @@
 require('coffeescript').register();
 
 const _ = require('lodash');
+const nodeUtil = require('util');
 
 db = require('../../heap/back/db');
 testUtil = require('../../heap/test/util');
@@ -15,6 +16,8 @@ const waitIfIos = async () => {
     await new Promise(resolve => setTimeout(resolve, 15000));
   }
 }
+
+const flushAllRedis = nodeUtil.promisify((done) => db.orm.connection.sharedRedis().flushall(done));
 
 const assertEvent = (err, res, check) => {
   assert.not.exist(err);
@@ -208,4 +211,5 @@ module.exports = {
   assertNavigationEvent,
   pollForSentinel,
   waitIfIos,
+  flushAllRedis,
 };

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -15,9 +15,11 @@ const waitIfIos = async () => {
     console.log('Waiting 15s to flush iOS events.');
     await new Promise(resolve => setTimeout(resolve, 15000));
   }
-}
+};
 
-const flushAllRedis = nodeUtil.promisify((done) => db.orm.connection.sharedRedis().flushall(done));
+const flushAllRedis = nodeUtil.promisify(done =>
+  db.orm.connection.sharedRedis().flushall(done)
+);
 
 const assertEvent = (err, res, check) => {
   assert.not.exist(err);


### PR DESCRIPTION
A few small test improvements (best reviewed commit-by-commit):
* Refactor page-level hierarchies into constant
* Only wait for iOS to flush on iOS tests (reduces android test run times by minutes)
* Fix nesting for Basics (previously, a failed `before` for autocapture tests wouldn't prevent autocapture tests from running)
* Pull redis `flushall()` into promisified util
* Reduce android flakes caused by the keyboard being in the way when a button should be tapped