### PR TITLE
Fix generate_settings reference

### DIFF
--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
 
   s.script_phase = {
     name: 'Generate `HeapSettings.plist`',
-    script: '../../node_modules/@heap/react-native-heap/ios/HeapSettings.bundle/generate_settings',
+    script: '../../node_modules/@heap/react-native-heap/ios/HeapSettings.bundle/generate_settings.rb',
     execution_position: :after_compile,
     shell_path: '/bin/bash'
   }


### PR DESCRIPTION
This got missed in https://github.com/heap/react-native-heap/pull/132