### PR TITLE
Add basic web support

### DIFF
--- a/js/Heap.js
+++ b/js/Heap.js
@@ -1,6 +1,5 @@
 // Libraries
 import React from 'react';
-import { NativeModules } from 'react-native';
 
 import {
   HeapIgnore,
@@ -14,9 +13,10 @@ import { autocaptureTextInputChange } from './autotrack/textInput';
 import { checkDisplayNamePlugin } from './util/checkDisplayNames';
 import { withReactNavigationAutotrack } from './autotrack/reactNavigation';
 import { bailOnError } from './util/bailer';
+import Wrapper from "./Wrapper";
 
 const flatten = require('flat');
-const RNHeap = NativeModules.RNHeap;
+const RNHeap = new Wrapper();
 
 const track = bailOnError((event, payload) => {
   try {

--- a/js/Wrapper.native.js
+++ b/js/Wrapper.native.js
@@ -1,0 +1,14 @@
+import { NativeModules } from 'react-native';
+
+const RNHeap = NativeModules.RNHeap;
+
+export default class Wrapper {
+    track = (event, payload) => RNHeap.track(event, payload);
+    setAppId = (appId) => RNHeap.setAppId(appId);
+    identify = (identity) => RNHeap.identify(identity);
+    resetIdentity = () => RNHeap.resetIdentity();
+    addUserProperties = (payload) => RNHeap.addUserProperties(payload);
+    addEventProperties = (payload) => RNHeap.addEventProperties(payload);
+    removeEventProperty = (property) => RNHeap.removeEventProperty(property);
+    clearEventProperties = () => RNHeap.clearEventProperties();
+}

--- a/js/Wrapper.web.js
+++ b/js/Wrapper.web.js
@@ -1,0 +1,18 @@
+export default class Wrapper {
+    setAppId = (appId) => {
+        const head = document.getElementsByTagName("head")[0];
+        const heapScript = document.createElement("script");
+        heapScript.appendChild(document.createTextNode(`
+        window.heap=window.heap||[],heap.load=function(e,t){window.heap.appid=e,window.heap.config=t=t||{};var r=t.forceSSL||"https:"===document.location.protocol,a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=(r?"https:":"http:")+"//cdn.heapanalytics.com/js/heap-"+e+".js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n);for(var o=function(e){return function(){heap.push([e].concat(Array.prototype.slice.call(arguments,0)))}},p=["addEventProperties","addUserProperties","clearEventProperties","identify","resetIdentity","removeEventProperty","setEventProperties","track","unsetEventProperty"],c=0;c<p.length;c++)heap[p[c]]=o(p[c])};
+        heap.load("${appId}");
+        `));
+        head.appendChild(heapScript);
+    };
+    track = (event, payload) => window.heap.track(event, payload);
+    identify = (identity) => window.heap.identify(identity);
+    resetIdentity = () => window.heap.resetIdentity();
+    addUserProperties = (payload) => window.heap.addUserProperties(payload);
+    addEventProperties = (payload) => window.heap.addEventProperties(payload);
+    removeEventProperty = (property) => window.heap.removeEventProperty(property);
+    clearEventProperties = () => window.heap.clearEventProperties();
+}


### PR DESCRIPTION
Pretty basic first pass to support react-native-web via a small wrapper around the native module backstopping it with the heap js library.

autotracking presses doesn't seem to work, which I may dig into, but this seemed like a good place to start and get some thoughts.