### PR TITLE
[HEAP-10464] Use correct conventions for HOC display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
 ### Changed
+- Updated higher-order components to use display name conventions (described [here](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)).
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -7,7 +7,7 @@ testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
 const BASICS_PAGE_TOP_HIERARCHY =
-  'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|';
+  'AppContainer;|App;|Provider;|withReactNavigationAutotrack(NavigationContainer);|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|';
 
 const doTestActions = async () => {
   // Open the Basics tab in the tab navigator.

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -7,7 +7,7 @@ testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
 const HEAPIGNORE_PAGE_TOP_HIERARCHY =
-  'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|';
+  'AppContainer;|App;|Provider;|withReactNavigationAutotrack(NavigationContainer);|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|';
 
 const doTestActions = async () => {
   // Open the HeapIgnore tab in the tab navigator.
@@ -16,6 +16,7 @@ const doTestActions = async () => {
   await expect(element(by.id('totallyIgnored'))).toBeVisible();
   await element(by.id('totallyIgnored')).tap();
   await element(by.id('totallyIgnoredHoc')).tap();
+  await element(by.id('allowedAllPropsHoc')).tap();
 
   await rnTestUtil.waitIfIos();
 
@@ -70,6 +71,13 @@ describe('HeapIgnore', () => {
     await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
       touchableHierarchy: expectedHierarchy,
       targetText: 'Foobar',
+    });
+  });
+
+  it('should allow everything except target text HOC', async () => {
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}withHeapIgnore(TouchableOpacity);[testID=allowedAllPropsHoc];|HeapIgnore;|TouchableOpacity;[testID=allowedAllPropsHoc];|`;
+    await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
+      touchableHierarchy: expectedHierarchy,
     });
   });
 

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -9,7 +9,7 @@ const IOS_BUTTON_SUFFIX = 'TouchableOpacity;';
 const ANDROID_BUTTON_SUFFIX = 'TouchableNativeFeedback;';
 
 const PROPEXTRACTION_PAGE_TOP_HIERARCHY =
-  'AppContainer;|App;|Provider;|HeapNavigationWrapper;|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|';
+  'AppContainer;|App;|Provider;|withReactNavigationAutotrack(NavigationContainer);|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|';
 
 const doTestActions = async () => {
   // Open the PropExtraction tab in the tab navigator.

--- a/examples/TestDriver/src/pages/heapIgnore.js
+++ b/examples/TestDriver/src/pages/heapIgnore.js
@@ -13,6 +13,13 @@ const Foo = props => {
 
 const TouchableOpacityWithHeapIgnore = Heap.withHeapIgnore(TouchableOpacity);
 
+const TouchableOpacityWithHeapIgnoredTargetText = Heap.withHeapIgnore(TouchableOpacity, {
+  allowInteraction: true,
+  allowInnerHierarchy: true,
+  allowAllProps: true,
+  allowTargetText: false,
+});
+
 export default class HeapIgnorePage extends Component {
   render() {
     return (
@@ -29,6 +36,9 @@ export default class HeapIgnorePage extends Component {
             <Text>Foobar</Text>
           </TouchableOpacityWithHeapIgnore>
         </Foo>
+        <TouchableOpacityWithHeapIgnoredTargetText testID="allowedAllPropsHoc">
+          <Text>Foobar</Text>
+        </TouchableOpacityWithHeapIgnoredTargetText>
         <HeapIgnore allowInteraction={true}>
           <TouchableOpacity testID="allowedInteraction">
             <Text>Foobar</Text>

--- a/examples/TestDriver/src/pages/heapIgnore.js
+++ b/examples/TestDriver/src/pages/heapIgnore.js
@@ -13,12 +13,15 @@ const Foo = props => {
 
 const TouchableOpacityWithHeapIgnore = Heap.withHeapIgnore(TouchableOpacity);
 
-const TouchableOpacityWithHeapIgnoredTargetText = Heap.withHeapIgnore(TouchableOpacity, {
-  allowInteraction: true,
-  allowInnerHierarchy: true,
-  allowAllProps: true,
-  allowTargetText: false,
-});
+const TouchableOpacityWithHeapIgnoredTargetText = Heap.withHeapIgnore(
+  TouchableOpacity,
+  {
+    allowInteraction: true,
+    allowInnerHierarchy: true,
+    allowAllProps: true,
+    allowTargetText: false,
+  }
+);
 
 export default class HeapIgnorePage extends Component {
   render() {

--- a/js/autotrack/__tests__/heapIgnore.spec.js
+++ b/js/autotrack/__tests__/heapIgnore.spec.js
@@ -208,7 +208,7 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         touchableHierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|_class;[testID=targetElement];|HeapIgnore;|Text;|',
+          'WrapperComponent;|Foo;|BarClass;|BarFunction;|withHeapIgnore(Text);[testID=targetElement];|HeapIgnore;|Text;|',
       });
     });
 

--- a/js/autotrack/heapIgnore.js
+++ b/js/autotrack/heapIgnore.js
@@ -1,6 +1,8 @@
 import * as _ from 'lodash';
 import React from 'react';
 
+import { getComponentDisplayName } from '../util/hocUtil';
+
 export const HeapIgnore = props => {
   // The only purpose of HeapIgnore is to tell the us which props apply to the subtree when we're
   // traversing, so we just need to render it's children here.
@@ -36,7 +38,9 @@ export const withHeapIgnore = (IgnoredComponent, heapIgnoreConfig) => {
   }
 
   // :TODO: (jmtaber129): Change this to 'withHeapIgnore(<IgnoredComponent name>).
-  WithHeapIgnore.displayName = '_class';
+  WithHeapIgnore.displayName = `withHeapIgnore(${getComponentDisplayName(
+    IgnoredComponent
+  )})`;
 
   return React.forwardRef((props, ref) => {
     return <WithHeapIgnore {...props} forwardedRef={ref} />;

--- a/js/autotrack/heapIgnore.js
+++ b/js/autotrack/heapIgnore.js
@@ -37,7 +37,6 @@ export const withHeapIgnore = (IgnoredComponent, heapIgnoreConfig) => {
     }
   }
 
-  // :TODO: (jmtaber129): Change this to 'withHeapIgnore(<IgnoredComponent name>).
   WithHeapIgnore.displayName = `withHeapIgnore(${getComponentDisplayName(
     IgnoredComponent
   )})`;

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { bail, bailOnError } from '../util/bailer';
+import { getComponentDisplayName } from '../util/hocUtil';
 import NavigationUtil from '../util/navigationUtil';
 
 const EVENT_TYPE = 'reactNavigationScreenview';
@@ -83,6 +84,10 @@ export const withReactNavigationAutotrack = track => AppContainer => {
       );
     }
   }
+
+  HeapNavigationWrapper.displayName = `withReactNavigationAutotrack(${getComponentDisplayName(
+    AppContainer
+  )})`;
 
   return React.forwardRef((props, ref) => {
     return <HeapNavigationWrapper {...props} forwardedRef={ref} />;

--- a/js/util/hocUtil.js
+++ b/js/util/hocUtil.js
@@ -1,0 +1,3 @@
+export const getComponentDisplayName = WrappedComponent => {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+};


### PR DESCRIPTION
## Description
Use `displayName` conventions for higher-order components (described [here](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)).

This will break any event definitions relying on the component naming of `HeapNavigationWrapper` (for `withReactNavigationAutotrack`) or `_class` (for `withHeapIgnore`).  These aren't semantically meaningful, and likely aren't used for event def.

## Test Plan
* Updated all detox test to use new display names in hierarchies.
* Updated HeapIgnore unit test to use new display names in hierarchies.
* Added detox test case for HeapIgnore HOC display name.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
