### PR TITLE
EXAMPLE: Ignore native iOS events within the react UIView

### DIFF
--- a/examples/TestDriver/ios/TestDriver/AppDelegate.m
+++ b/examples/TestDriver/ios/TestDriver/AppDelegate.m
@@ -38,6 +38,7 @@
                                                       moduleName:@"TestDriver"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
+  [rootView setValue:@true forKey:@"heapIgnore"];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];


### PR DESCRIPTION
This line specifies that the native iOS SDK should ignore all native events (`RCTTouchHandler`, etc.) within the root view of the React Native app.

As a result, all native events from the iOS SDK (which may be noisy or have `accessibilityLabel`s that contain PII) will be suppressed within the view that renders the React Native app.