### PR TITLE
Fix test app detox android build

### DIFF
--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -143,6 +143,10 @@ android {
             }
         }
     }
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -12,7 +12,7 @@
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",
-    "react-native-gesture-handler": "^1.1.0",
+    "react-native-gesture-handler": "1.3.0",
     "react-navigation": "^3.3.2",
     "react-redux": "^5.1.1",
     "redux": "^4.0.1"


### PR DESCRIPTION
## Description
At some point, the TestDriver test app started using a newer version of `react-native-gesture-handler`, which caused build issues on android.  Pinned this dep's version to an earlier version, and updated compile options to address other build issues that arose.

## Test Plan
Detox tests.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (test app only - not a bugfix/feature)
