### PR TITLE
Refactor bridge and methods to look like frameworks API

### DIFF
--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -2,7 +2,8 @@ const reactNative = jest.genMockFromModule('react-native');
 
 reactNative.NativeModules = {
   RNHeap: {
-    track: jest.fn(),
+    manuallyTrackEvent: jest.fn(),
+    autocaptureEvent: jest.fn(),
     setAppId: jest.fn(),
     identify: jest.fn(),
     resetIdentity: jest.fn(),

--- a/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
+++ b/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
@@ -95,7 +95,16 @@ public class RNHeapLibraryModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void track(String event, ReadableMap payload) {
+  public void autocaptureEvent(String event, ReadableMap payload) {
+    // :TODO: (jmtaber129): Update this to look like:
+    // Heap.track(event, convertToStringMap(payload), "react_native").
+    Heap.track(event, convertToStringMap(payload));
+  }
+
+  @ReactMethod
+  public void manuallyTrackEvent(String event, ReadableMap payload, ReadableMap contextualProps) {
+    // :TODO: (jmtaber129): Update this to look like:
+    // Heap.track(event, convertToStringMap(payload), "react_native", contextualProps).
     Heap.track(event, convertToStringMap(payload));
   }
 }

--- a/ios/RNHeap.m
+++ b/ios/RNHeap.m
@@ -31,7 +31,23 @@ RCT_EXPORT_METHOD(setAppId:(NSString *)appId) {
     }
 }
 
-RCT_EXPORT_METHOD(track:(NSString *)event withProperties:(NSDictionary *)properties) {
+RCT_EXPORT_METHOD(autocaptureEvent:(NSString *)event withProperties:(NSDictionary *)properties) {
+  [self checkForPageview];
+
+  // :TODO: (jmtaber129): Change this to look like:
+  // [Heap track:event withProperties:properties withFramework:"react_native"]
+  [Heap track:event withProperties:properties];
+}
+
+RCT_EXPORT_METHOD(manuallyTrackEvent:(NSString *)event withProperties:(NSDictionary *)properties withContext:(NSDictionary *)contextProperties) {
+  [self checkForPageview];
+
+  // :TODO: (jmtaber129): Change this to look like:
+  // [Heap track:event withProperties:properties withFramework:"react_native" withContextProperties:contextProperties]
+  [Heap track:event withProperties:properties];
+}
+
+-(void) checkForPageview {
     // The Heap library requires that a "page view" event be sent first, since properties
     // will get copied down to manual events.  Unfortunately, the first page view happens
     // before any JS code is run, and so the app doesn't yet have an ID.  This unfortunate
@@ -47,7 +63,6 @@ RCT_EXPORT_METHOD(track:(NSString *)event withProperties:(NSDictionary *)propert
         pageViewSent = YES;
     }
     #pragma clang diagnostic pop
-  [Heap track:event withProperties:properties];
 }
 
 RCT_EXPORT_METHOD(identify:(NSString *)identity) {

--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -24,8 +24,8 @@ describe('The Heap object', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    NativeModules.RNHeap.track.mockReset();
-    mockTrack = NativeModules.RNHeap.track;
+    NativeModules.RNHeap.manuallyTrackEvent.mockReset();
+    mockTrack = NativeModules.RNHeap.manuallyTrackEvent;
 
     NativeModules.RNHeap.setAppId.mockReset();
     mockSetAppId = NativeModules.RNHeap.setAppId;


### PR DESCRIPTION
## Description
Refactor bridge methods to prep for the frameworks API that will be provided by the native libs.

## Test Plan
Existing tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (just a refactor)