### PR TITLE
[HEAP-11501] Use iOS Framework track methods

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -79,7 +79,7 @@ describe('Basic React Native and Interaction Support', () => {
           return !(
             _.includes(event.k, 'eventProp1') ||
             _.includes(event.k, 'eventProp2') ||
-            _.includes(event.k, 'path')
+            _.includes(event.sprops, 'path')
           );
         }
       );
@@ -92,7 +92,7 @@ describe('Basic React Native and Interaction Support', () => {
           return (
             _.includes(event.k, 'eventProp1') &&
             _.includes(event.k, 'eventProp2') &&
-            !_.includes(event.k, 'path')
+            !_.includes(event.sprops, 'path')
           );
         }
       );
@@ -105,7 +105,7 @@ describe('Basic React Native and Interaction Support', () => {
           return (
             !_.includes(event.k, 'eventProp1') &&
             _.includes(event.k, 'eventProp2') &&
-            !_.includes(event.k, 'path')
+            !_.includes(event.sprops, 'path')
           );
         }
       );
@@ -118,7 +118,7 @@ describe('Basic React Native and Interaction Support', () => {
           return !(
             _.includes(event.k, 'eventProp1') ||
             _.includes(event.k, 'eventProp2') ||
-            _.includes(event.k, 'path')
+            _.includes(event.sprops, 'path')
           );
         }
       );

--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -16,15 +16,19 @@ const doTestActions = async () => {
   await expect(element(by.id('navigate_stack'))).toBeVisible();
   await element(by.id('navigate_stack')).tap();
   await delay();
+
+  await rnTestUtil.waitIfIos();
+
   await expect(element(by.id('pop1'))).toBeVisible();
   await element(by.id('pop1')).tap();
   await delay();
 
-  await rnTestUtil.waitIfIos();
-
   await expect(element(by.id('navigate_modal'))).toBeVisible();
   await element(by.id('navigate_modal')).tap();
   await delay();
+
+  await rnTestUtil.waitIfIos();
+
   await expect(element(by.id('pop2'))).toBeVisible();
   await element(by.id('pop2')).tap();
   await delay();

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -125,7 +125,7 @@ const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
 const assertIosNavigationEvent = async (expectedPath, expectedType) => {
   const commonProps = ['path', expectedPath];
   const props = expectedType
-    ? [...commonProps, 'type', expectedType]
+    ? [...commonProps, 'action', expectedType]
     : commonProps;
   return assertIosPixel({
     t: 'reactNavigationScreenview',

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -89,7 +89,8 @@ const assertAutotrackHierarchy = async (expectedName, expectedProps) => {
       t: expectedName,
       // Convert { key1: 'value1', key2: 'value2'} to ['key1', 'value1', 'key2', 'value2'] for
       // custom props.
-      k: _.flatMap(expectedProps, (value, key) => [key, value]),
+      source: 'react_native',
+      sprops: _.flatMap(expectedProps, (value, key) => [key, value]),
     });
   } else {
     throw new Error(`Unknown device type: ${device.getPlatform()}`);
@@ -129,7 +130,8 @@ const assertIosNavigationEvent = async (expectedPath, expectedType) => {
     : commonProps;
   return assertIosPixel({
     t: 'reactNavigationScreenview',
-    k: props,
+    source: 'react_native',
+    sprops: props,
   });
 };
 

--- a/ios/RNHeap.m
+++ b/ios/RNHeap.m
@@ -34,16 +34,12 @@ RCT_EXPORT_METHOD(setAppId:(NSString *)appId) {
 RCT_EXPORT_METHOD(autocaptureEvent:(NSString *)event withProperties:(NSDictionary *)properties) {
   [self checkForPageview];
 
-  // :TODO: (jmtaber129): Change this to look like:
-  // [Heap track:event withProperties:properties withFramework:"react_native"]
   [Heap frameworkAutocaptureEvent:event withSource:@"react_native" withSourceProperties:properties];
 }
 
 RCT_EXPORT_METHOD(manuallyTrackEvent:(NSString *)event withProperties:(NSDictionary *)properties withContext:(NSDictionary *)contextProperties) {
   [self checkForPageview];
 
-  // :TODO: (jmtaber129): Change this to look like:
-  // [Heap track:event withProperties:properties withFramework:"react_native" withContextProperties:contextProperties]
   [Heap frameworkTrack:event withProperties:properties withSource:@"react_native" withSourceProperties:contextProperties];
 }
 

--- a/ios/RNHeap.m
+++ b/ios/RNHeap.m
@@ -36,7 +36,7 @@ RCT_EXPORT_METHOD(autocaptureEvent:(NSString *)event withProperties:(NSDictionar
 
   // :TODO: (jmtaber129): Change this to look like:
   // [Heap track:event withProperties:properties withFramework:"react_native"]
-  [Heap track:event withProperties:properties];
+  [Heap frameworkAutocaptureEvent:event withSource:@"react_native" withSourceProperties:properties];
 }
 
 RCT_EXPORT_METHOD(manuallyTrackEvent:(NSString *)event withProperties:(NSDictionary *)properties withContext:(NSDictionary *)contextProperties) {
@@ -44,7 +44,7 @@ RCT_EXPORT_METHOD(manuallyTrackEvent:(NSString *)event withProperties:(NSDiction
 
   // :TODO: (jmtaber129): Change this to look like:
   // [Heap track:event withProperties:properties withFramework:"react_native" withContextProperties:contextProperties]
-  [Heap track:event withProperties:properties];
+  [Heap frameworkTrack:event withProperties:properties withSource:@"react_native" withSourceProperties:contextProperties];
 }
 
 -(void) checkForPageview {

--- a/ios/Vendor/Heap.h
+++ b/ios/Vendor/Heap.h
@@ -1,6 +1,6 @@
 //
 //  Heap.h
-//  Version 6.2.1
+//  Version 6.5.0-alpha.1
 //  Copyright (c) 2014 Heap Inc. All rights reserved.
 //
 
@@ -145,6 +145,39 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (void)track:(NSString *)event withProperties:(nullable NSDictionary *)properties;
 
+/**
+ * Track an autocaptured framework event.
+ *
+ * Only supported source types will be processed correctly. Unsupported source
+ * types will not be processed as framework events.
+ *
+ * @param event              the event name
+ * @param source             the source name
+ * @param sourceProperties   key-value pairs to associate with the framework event
+ *
+ * @see frameworkTrack:withProperties:withSource:withSourceProperties:
+ */
++ (void)frameworkAutocaptureEvent:(NSString *)event
+                       withSource:(NSString *)source
+             withSourceProperties:(nullable NSDictionary *)sourceProperties;
+
+/**
+ * Track a custom event from a framework with properties and framework context.
+ *
+ * Only supported source types will be processed correctly. Unsupported source
+ * types will not be processed as framework events.
+ *
+ * @param event              the event name
+ * @param properties         key-value pairs to associate with the event
+ * @param source             the source name
+ * @param sourceProperties   key-value pairs to associate with the framework context of the event
+ *
+ * @see @frameworkAutocaptureEvent:withSource:withSourceProperties:
+ */
++ (void)frameworkTrack:(NSString *)event
+        withProperties:(nullable NSDictionary *)properties
+            withSource:(NSString *)source
+  withSourceProperties:(nullable NSDictionary *)sourceProperties;
 
 /// @name Global event properties
 

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -29,7 +29,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
 
       track(EVENT_TYPE, {
         path: initialPageviewPath,
-        type: INITIAL_ROUTE_TYPE,
+        action: INITIAL_ROUTE_TYPE,
       });
     }
 
@@ -73,7 +73,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
             if (prevScreenRoute !== nextScreenRoute) {
               track(EVENT_TYPE, {
                 path: nextScreenRoute,
-                type: action.type,
+                action: action.type,
               });
             }
           })}


### PR DESCRIPTION
## Description
* Upgrade the vendored iOS Heap dependency to 6.5.0-alpha.1
* Switch the native iOS methods the bridge uses from custom track to the framework track methods provided in Heap iOS v6.5.0
* Change the `type` field in navigation events to `action`, since `type` is reserved for the event name
* Update tests + test utils to use `source` and `sprops` pixel params.

This will introduce inconsistency between how iOS and Android events are sent and processed server-side, so merging into `feature/rnfcl` for now.

## Test Plan
Updated + ran detox tests, and observed correct events coming to kafka.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (will be updated right before `feature/rnfcl` is merged into develop)
