### PR TITLE
[HEAP-11507] Revise names of event types + props

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -323,10 +323,10 @@ describe('Basic React Native and Interaction Support', () => {
     it("should autotrack 'TouchableOpacity's", async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableOpacity;[testID=touchableOpacityText];|`;
       const expectedTargetText = 'Touchable Opacity Foo';
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        touchableHierarchy: expectedHierarchy,
-        targetText: expectedTargetText,
-        screenName: 'Basics',
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        hierarchy: expectedHierarchy,
+        target_text: expectedTargetText,
+        screen_name: 'Basics',
         path: 'Basics',
       });
     });
@@ -334,10 +334,10 @@ describe('Basic React Native and Interaction Support', () => {
     it("should autotrack 'TouchableHighlight's", async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableHighlight;[testID=touchableHighlightText];|`;
       const expectedTargetText = 'Touchable Highlight';
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        touchableHierarchy: expectedHierarchy,
-        targetText: expectedTargetText,
-        screenName: 'Basics',
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        hierarchy: expectedHierarchy,
+        target_text: expectedTargetText,
+        screen_name: 'Basics',
         path: 'Basics',
       });
     });
@@ -345,10 +345,10 @@ describe('Basic React Native and Interaction Support', () => {
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|`;
       const expectedTargetText = 'Touchable Without Feedback';
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        touchableHierarchy: expectedHierarchy,
-        targetText: expectedTargetText,
-        screenName: 'Basics',
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        hierarchy: expectedHierarchy,
+        target_text: expectedTargetText,
+        screen_name: 'Basics',
         path: 'Basics',
       });
     });
@@ -356,48 +356,48 @@ describe('Basic React Native and Interaction Support', () => {
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|`;
       const expectedTargetText = 'Touchable Native Feedback';
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        touchableHierarchy: expectedHierarchy,
-        targetText: expectedTargetText,
-        screenName: 'Basics',
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        hierarchy: expectedHierarchy,
+        target_text: expectedTargetText,
+        screen_name: 'Basics',
         path: 'Basics',
       });
     });
 
     it("should autotrack 'Switch's", async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}Switch;[testID=switch];|`;
-      await rnTestUtil.assertAutotrackHierarchy('_handleChange', {
-        touchableHierarchy: expectedHierarchy,
-        screenName: 'Basics',
+      await rnTestUtil.assertAutotrackHierarchy('change', {
+        hierarchy: expectedHierarchy,
+        screen_name: 'Basics',
         path: 'Basics',
       });
     });
 
     it("should autotrack NativeBase 'Switch's", async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}StyledComponent;[testID=nbSwitch];|Switch;[testID=nbSwitch];|Switch;[testID=nbSwitch];|`;
-      await rnTestUtil.assertAutotrackHierarchy('_handleChange', {
-        touchableHierarchy: expectedHierarchy,
-        screenName: 'Basics',
+      await rnTestUtil.assertAutotrackHierarchy('change', {
+        hierarchy: expectedHierarchy,
+        screen_name: 'Basics',
         path: 'Basics',
       });
     });
 
     it('should autotrack ScrollView paging', async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}FlatList;[testID=scrollView];|VirtualizedList;[testID=scrollView];|ScrollView;[testID=scrollView];|`;
-      await rnTestUtil.assertAutotrackHierarchy('scrollViewPage', {
-        touchableHierarchy: expectedHierarchy,
-        pageIndex: '1',
-        screenName: 'Basics',
+      await rnTestUtil.assertAutotrackHierarchy('scroll_view_page', {
+        hierarchy: expectedHierarchy,
+        page_index: '1',
+        screen_name: 'Basics',
         path: 'Basics',
       });
     });
 
     it('should autotrack TextInput edits', async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}MyTextInput;[testID=textInput];|TextInput;[testID=textInput];|`;
-      await rnTestUtil.assertAutotrackHierarchy('textEdit', {
-        touchableHierarchy: expectedHierarchy,
-        placeholderText: 'foo placeholder',
-        screenName: 'Basics',
+      await rnTestUtil.assertAutotrackHierarchy('text_edit', {
+        hierarchy: expectedHierarchy,
+        placeholder_text: 'foo placeholder',
+        screen_name: 'Basics',
         path: 'Basics',
       });
     });

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -54,37 +54,37 @@ describe('HeapIgnore', () => {
 
   it('should ignore the inner hierarchy', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|`;
-    await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-      touchableHierarchy: expectedHierarchy,
+    await rnTestUtil.assertAutotrackHierarchy('touch', {
+      hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore props and target text', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|TouchableOpacity;|`;
-    await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-      touchableHierarchy: expectedHierarchy,
+    await rnTestUtil.assertAutotrackHierarchy('touch', {
+      hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore props', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|TouchableOpacity;|`;
-    await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-      touchableHierarchy: expectedHierarchy,
-      targetText: 'Foobar',
+    await rnTestUtil.assertAutotrackHierarchy('touch', {
+      hierarchy: expectedHierarchy,
+      target_text: 'Foobar',
     });
   });
 
   it('should allow everything except target text HOC', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}withHeapIgnore(TouchableOpacity);[testID=allowedAllPropsHoc];|HeapIgnore;|TouchableOpacity;[testID=allowedAllPropsHoc];|`;
-    await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-      touchableHierarchy: expectedHierarchy,
+    await rnTestUtil.assertAutotrackHierarchy('touch', {
+      hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore target text', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnoreTargetText;|HeapIgnore;|TouchableOpacity;[testID=ignoredTargetText];|`;
-    await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-      touchableHierarchy: expectedHierarchy,
+    await rnTestUtil.assertAutotrackHierarchy('touch', {
+      hierarchy: expectedHierarchy,
     });
   });
 });

--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -71,18 +71,18 @@ describe('Navigation', () => {
     });
 
     it('tracks events with screen name props', async () => {
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        screenName: 'Base',
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        screen_name: 'Base',
         path: 'Nav::MainStack::Base',
       });
 
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        screenName: 'StackCard',
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        screen_name: 'StackCard',
         path: 'Nav::MainStack::StackCard',
       });
 
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        screenName: 'ModalStack',
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        screen_name: 'ModalStack',
         path: 'Nav::ModalStack',
       });
     });

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -51,9 +51,9 @@ describe('Property Extraction in Hierarchies', () => {
         device.getPlatform() === 'ios'
           ? 'testButtonTitle1'
           : 'TESTBUTTONTITLE1';
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        touchableHierarchy: expectedHierarchy,
-        targetText: expectedTargetText,
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        hierarchy: expectedHierarchy,
+        target_text: expectedTargetText,
       });
     });
 
@@ -63,9 +63,9 @@ describe('Property Extraction in Hierarchies', () => {
         device.getPlatform() === 'ios'
           ? 'testButtonTitle2'
           : 'TESTBUTTONTITLE2';
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        touchableHierarchy: expectedHierarchy,
-        targetText: expectedTargetText,
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        hierarchy: expectedHierarchy,
+        target_text: expectedTargetText,
       });
     });
 
@@ -77,9 +77,9 @@ describe('Property Extraction in Hierarchies', () => {
         device.getPlatform() === 'ios'
           ? 'testButtonTitle3'
           : 'TESTBUTTONTITLE3';
-      await rnTestUtil.assertAutotrackHierarchy('touchableHandlePress', {
-        touchableHierarchy: expectedHierarchy,
-        targetText: expectedTargetText,
+      await rnTestUtil.assertAutotrackHierarchy('touch', {
+        hierarchy: expectedHierarchy,
+        target_text: expectedTargetText,
       });
     });
   });

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -116,7 +116,7 @@ const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
     envId: HEAP_ENV_ID,
     event: {
       custom: {
-        name: 'reactNavigationScreenview',
+        name: 'react_navigation_screenview',
         properties: props,
       },
     },
@@ -129,7 +129,7 @@ const assertIosNavigationEvent = async (expectedPath, expectedType) => {
     ? [...commonProps, 'action', expectedType]
     : commonProps;
   return assertIosPixel({
-    t: 'reactNavigationScreenview',
+    t: 'react_navigation_screenview',
     source: 'react_native',
     sprops: props,
   });

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -106,7 +106,7 @@ const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
   const props = expectedType
     ? {
         ...commonProps,
-        type: {
+        action: {
           string: expectedType,
         },
       }

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -110,7 +110,7 @@ const instrumentScrollView = path => {
       path.node.value, // originalFunctionExpression
       t.thisExpression(), // thisExpression
       'autocaptureScrollView', // autotrackMethodName
-      'scrollViewPage' // eventType
+      'scroll_view_page' // eventType
     );
     path.get('value').replaceWith(replacementFunc);
   }
@@ -139,7 +139,7 @@ const instrumentTextInput = path => {
       path.node.value, // originalFunctionExpression
       t.identifier('this'), // thisExpression
       'autocaptureTextInput', // autotrackMethodName
-      'textEdit' // eventType
+      'text_edit' // eventType
     );
     path.get('value').replaceWith(replacementFunc);
   }
@@ -250,7 +250,7 @@ const instrumentSwitchComponent = path => {
     originalFunctionExpression, // originalFunctionExpression
     t.identifier('_this'), // thisExpression
     'autotrackSwitchChange', // autotrackMethodName
-    path.node.left.property.name // eventType
+    'change' // eventType
   );
 
   path.get('right').replaceWith(replacementFunc);

--- a/instrumentor/test/fixtures/is-scroll-view-createreactclass/output.js
+++ b/instrumentor/test/fixtures/is-scroll-view-createreactclass/output.js
@@ -11,7 +11,7 @@ var ScrollView = createReactClass({
       onMomentumScrollEnd: function onMomentumScrollEnd(e) {
         var Heap = require('@heap/react-native-heap').default;
 
-        Heap.autocaptureScrollView("scrollViewPage", _this, e);
+        Heap.autocaptureScrollView("scroll_view_page", _this, e);
 
         _this.scrollResponderHandleMomentumScrollEnd.call(_this, e);
       }

--- a/instrumentor/test/fixtures/is-scroll-view-extends-component/output.js
+++ b/instrumentor/test/fixtures/is-scroll-view-extends-component/output.js
@@ -42,7 +42,7 @@ var ScrollView = function (_React$Component) {
         onMomentumScrollEnd: function onMomentumScrollEnd(e) {
           var Heap = require('@heap/react-native-heap').default;
 
-          Heap.autocaptureScrollView("scrollViewPage", _this2, e);
+          Heap.autocaptureScrollView("scroll_view_page", _this2, e);
 
           _this2._scrollResponder.scrollResponderHandleMomentumScrollEnd.call(_this2, e);
         }

--- a/instrumentor/test/fixtures/is-switch/output.js
+++ b/instrumentor/test/fixtures/is-switch/output.js
@@ -29,7 +29,7 @@ var Switch = function (_React$Component) {
     _this._handleChange = function (e) {
       var Heap = require('@heap/react-native-heap').default;
 
-      Heap.autotrackSwitchChange("_handleChange", _this, e);
+      Heap.autotrackSwitchChange("change", _this, e);
       (function (event) {
         if (_this._nativeSwitchRef == null) {
           return;

--- a/instrumentor/test/fixtures/is-text-input/output.js
+++ b/instrumentor/test/fixtures/is-text-input/output.js
@@ -4,7 +4,7 @@ var TextInput = createReactClass({
   _onChange: function _onChange(e) {
     var Heap = require('@heap/react-native-heap').default;
 
-    Heap.autocaptureTextInput("textEdit", this, e);
+    Heap.autocaptureTextInput("text_edit", this, e);
     (function (event) {
       if (this._inputRef && this._inputRef.setNativeProps) {
         ReactNative.setNativeProps(this._inputRef, {

--- a/js/autotrack/__tests__/heapIgnore.spec.js
+++ b/js/autotrack/__tests__/heapIgnore.spec.js
@@ -50,8 +50,8 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        targetText: 'foobar',
-        touchableHierarchy:
+        target_text: 'foobar',
+        hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|Text;[testID=targetElement];|',
       });
     });
@@ -84,9 +84,8 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        targetText: 'foobar',
-        touchableHierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|',
+        target_text: 'foobar',
+        hierarchy: 'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|',
       });
     });
 
@@ -107,8 +106,8 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        targetText: 'foobar',
-        touchableHierarchy:
+        target_text: 'foobar',
+        hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;|',
       });
     });
@@ -130,7 +129,7 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        touchableHierarchy:
+        hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;[testID=targetElement];|',
       });
     });
@@ -155,8 +154,8 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        targetText: 'foobar',
-        touchableHierarchy:
+        target_text: 'foobar',
+        hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;[testID=targetElement];|',
       });
     });
@@ -187,7 +186,7 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        touchableHierarchy:
+        hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|BarFunction;|HeapIgnore;|',
       });
     });
@@ -207,7 +206,7 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        touchableHierarchy:
+        hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|withHeapIgnore(Text);[testID=targetElement];|HeapIgnore;|Text;|',
       });
     });
@@ -225,7 +224,7 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        touchableHierarchy:
+        hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnoreTargetText;|HeapIgnore;|Text;[testID=targetElement];|',
       });
     });

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -16,10 +16,10 @@ interface Component extends ReactComponent {
 
 // Base properties for autotracked events.
 interface AutotrackProps {
-  touchableHierarchy: string;
-  targetText?: string;
+  hierarchy: string;
+  target_text?: string;
   path?: string;
-  screenName?: string;
+  screen_name?: string;
 }
 
 interface HeapIgnoreProps {
@@ -73,12 +73,12 @@ export const getBaseComponentProps: (
   const screenProps = NavigationUtil.getScreenPropsForCurrentRoute();
 
   const autotrackProps: AutotrackProps = {
-    touchableHierarchy: hierarchy,
+    hierarchy,
     ...screenProps,
   };
 
   if (targetText !== '') {
-    autotrackProps.targetText = targetText;
+    autotrackProps.target_text = targetText;
   }
 
   return autotrackProps;

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -3,7 +3,7 @@ import { bail, bailOnError } from '../util/bailer';
 import { getComponentDisplayName } from '../util/hocUtil';
 import NavigationUtil from '../util/navigationUtil';
 
-const EVENT_TYPE = 'reactNavigationScreenview';
+const EVENT_TYPE = 'react_navigation_screenview';
 
 // `react-native-navigation` uses `Navigation/{NAVIGATE,POP,BACK}` to represent
 // different types of navigation actions. We build the initial navigation action

--- a/js/autotrack/scrollViews.js
+++ b/js/autotrack/scrollViews.js
@@ -17,7 +17,7 @@ export const autotrackScrollView = track => (
   // particularly meaningful. Just leave out the target text.
   const autotrackProps = _.omit(
     getBaseComponentProps(componentThis),
-    'targetText'
+    'target_text'
   );
 
   if (!autotrackProps) {
@@ -31,7 +31,7 @@ export const autotrackScrollView = track => (
 
   // Integer props on android seem to come into Heap as decimals (regardless of whether the number is actually a float), while integer props
   // on iOS come into Heap as integers. To keep this prop consistent across platforms, send it as a string.
-  autotrackProps.pageIndex = `${Math.round(pageIndex)}`;
+  autotrackProps.page_index = `${Math.round(pageIndex)}`;
 
   track(eventType, autotrackProps);
 };

--- a/js/autotrack/textInput.js
+++ b/js/autotrack/textInput.js
@@ -32,7 +32,7 @@ const debouncedAutocaptureTextInputChange = track => (
   }
 
   if (componentThis.props.placeholder) {
-    autotrackProps.placeholderText = componentThis.props.placeholder;
+    autotrackProps.placeholder_text = componentThis.props.placeholder;
   }
 
   track(eventType, autotrackProps);

--- a/js/autotrack/touchables.js
+++ b/js/autotrack/touchables.js
@@ -15,6 +15,7 @@ export const autotrackPress = track => (eventType, componentThis, event) => {
     componentThis.state.touchable.touchState;
 
   autotrackProps.touchState = touchState;
+  autotrackProps.isLongPress = (eventType == 'touchableHandleLongPress');
 
-  track(eventType, autotrackProps);
+  track('touch', autotrackProps);
 };

--- a/js/autotrack/touchables.js
+++ b/js/autotrack/touchables.js
@@ -15,7 +15,7 @@ export const autotrackPress = track => (eventType, componentThis, event) => {
     componentThis.state.touchable.touchState;
 
   autotrackProps.touchState = touchState;
-  autotrackProps.isLongPress = (eventType == 'touchableHandleLongPress');
+  autotrackProps.isLongPress = eventType === 'touchableHandleLongPress';
 
   track('touch', autotrackProps);
 };

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -8,7 +8,7 @@ export default class NavigationUtil {
 
   static getScreenPropsForCurrentRoute(): {
     path: string;
-    screenName: string;
+    screen_name: string;
   } | null {
     if (
       !(this.heapNavRef && this.heapNavRef.state && this.heapNavRef.state.nav)
@@ -28,11 +28,11 @@ export default class NavigationUtil {
   // :TODO: (jmtaber129): Add type for navigationState.
   static getActiveRouteProps(
     navigationState: any
-  ): { path: string; screenName: string } {
+  ): { path: string; screen_name: string } {
     const paths = this.getActiveRouteNames(navigationState);
     return {
       path: paths.join('::'),
-      screenName: paths[paths.length - 1],
+      screen_name: paths[paths.length - 1],
     };
   }
 


### PR DESCRIPTION
## Description
Revised event type/prop names:
* `touchableHandlePress`/`touchableHandleLongPress` -> `touch`
* Added `isLongPress` to `touch` events to differentiate
* `_handleChange` -> `change`
* `touchableHierarchy` -> `hierarchy`
* All other event type/prop names converted from `lowerCamelCase` to `snake_case`.

## Test Plan
Updated existing tests, and observed incoming pixel requests.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (will be updated right before feature/rnfcl is merged into develop)
