### PR TITLE
[HEAP-11523] Send screen props as contextual framework props

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -74,12 +74,11 @@ describe('Basic React Native and Interaction Support', () => {
   describe(':ios: Bridge API', () => {
     it('should call first track', async () => {
       await rnTestUtil.assertIosPixel(
-        { a: '2084764307', t: 'pressInTestEvent1' },
+        { a: '2084764307', t: 'pressInTestEvent1', sprops: [ 'path', 'Basics', 'screen_name', 'Basics' ] },
         event => {
           return !(
             _.includes(event.k, 'eventProp1') ||
-            _.includes(event.k, 'eventProp2') ||
-            _.includes(event.sprops, 'path')
+            _.includes(event.k, 'eventProp2')
           );
         }
       );
@@ -87,12 +86,11 @@ describe('Basic React Native and Interaction Support', () => {
 
     it('should add event properties', async () => {
       await rnTestUtil.assertIosPixel(
-        { a: '2084764307', t: 'pressInTestEvent2' },
+        { a: '2084764307', t: 'pressInTestEvent2', sprops: [ 'path', 'Basics', 'screen_name', 'Basics' ] },
         event => {
           return (
             _.includes(event.k, 'eventProp1') &&
-            _.includes(event.k, 'eventProp2') &&
-            !_.includes(event.sprops, 'path')
+            _.includes(event.k, 'eventProp2')
           );
         }
       );
@@ -100,12 +98,11 @@ describe('Basic React Native and Interaction Support', () => {
 
     it('should remove event properties', async () => {
       await rnTestUtil.assertIosPixel(
-        { a: '2084764307', t: 'pressInTestEvent3' },
+        { a: '2084764307', t: 'pressInTestEvent3', sprops: [ 'path', 'Basics', 'screen_name', 'Basics' ]},
         event => {
           return (
             !_.includes(event.k, 'eventProp1') &&
-            _.includes(event.k, 'eventProp2') &&
-            !_.includes(event.sprops, 'path')
+            _.includes(event.k, 'eventProp2')
           );
         }
       );
@@ -113,12 +110,11 @@ describe('Basic React Native and Interaction Support', () => {
 
     it('should clear event properties', async () => {
       await rnTestUtil.assertIosPixel(
-        { a: '2084764307', t: 'pressInTestEvent4' },
+        { a: '2084764307', t: 'pressInTestEvent4', sprops: [ 'path', 'Basics', 'screen_name', 'Basics' ] },
         event => {
           return !(
             _.includes(event.k, 'eventProp1') ||
-            _.includes(event.k, 'eventProp2') ||
-            _.includes(event.sprops, 'path')
+            _.includes(event.k, 'eventProp2')
           );
         }
       );

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -74,7 +74,11 @@ describe('Basic React Native and Interaction Support', () => {
   describe(':ios: Bridge API', () => {
     it('should call first track', async () => {
       await rnTestUtil.assertIosPixel(
-        { a: '2084764307', t: 'pressInTestEvent1', sprops: [ 'path', 'Basics', 'screen_name', 'Basics' ] },
+        {
+          a: '2084764307',
+          t: 'pressInTestEvent1',
+          sprops: ['path', 'Basics', 'screen_name', 'Basics'],
+        },
         event => {
           return !(
             _.includes(event.k, 'eventProp1') ||
@@ -86,7 +90,11 @@ describe('Basic React Native and Interaction Support', () => {
 
     it('should add event properties', async () => {
       await rnTestUtil.assertIosPixel(
-        { a: '2084764307', t: 'pressInTestEvent2', sprops: [ 'path', 'Basics', 'screen_name', 'Basics' ] },
+        {
+          a: '2084764307',
+          t: 'pressInTestEvent2',
+          sprops: ['path', 'Basics', 'screen_name', 'Basics'],
+        },
         event => {
           return (
             _.includes(event.k, 'eventProp1') &&
@@ -98,7 +106,11 @@ describe('Basic React Native and Interaction Support', () => {
 
     it('should remove event properties', async () => {
       await rnTestUtil.assertIosPixel(
-        { a: '2084764307', t: 'pressInTestEvent3', sprops: [ 'path', 'Basics', 'screen_name', 'Basics' ]},
+        {
+          a: '2084764307',
+          t: 'pressInTestEvent3',
+          sprops: ['path', 'Basics', 'screen_name', 'Basics'],
+        },
         event => {
           return (
             !_.includes(event.k, 'eventProp1') &&
@@ -110,7 +122,11 @@ describe('Basic React Native and Interaction Support', () => {
 
     it('should clear event properties', async () => {
       await rnTestUtil.assertIosPixel(
-        { a: '2084764307', t: 'pressInTestEvent4', sprops: [ 'path', 'Basics', 'screen_name', 'Basics' ] },
+        {
+          a: '2084764307',
+          t: 'pressInTestEvent4',
+          sprops: ['path', 'Basics', 'screen_name', 'Basics'],
+        },
         event => {
           return !(
             _.includes(event.k, 'eventProp1') ||

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -14,6 +14,7 @@ import { autocaptureTextInputChange } from './autotrack/textInput';
 import { checkDisplayNamePlugin } from './util/checkDisplayNames';
 import { withReactNavigationAutotrack } from './autotrack/reactNavigation';
 import { bailOnError } from './util/bailer';
+import NavigationUtil from './util/navigationUtil';
 
 const flatten = require('flat');
 const RNHeap = NativeModules.RNHeap;
@@ -34,9 +35,10 @@ const manualTrack = bailOnError((event, payload) => {
     // simulate a failure.
     const flatten = require('flat');
 
+    const contextualProps = NavigationUtil.getScreenPropsForCurrentRoute();
+
     payload = payload || {};
-    // :TODO: (jmtaber129): Update 'contextualProps' to use screen props from react navigation.
-    RNHeap.manuallyTrackEvent(event, flatten(payload), /*contextualProps=*/ {});
+    RNHeap.manuallyTrackEvent(event, flatten(payload), contextualProps);
   } catch (e) {
     console.log('Error calling Heap.track\n', e);
   }

--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -55,8 +55,8 @@ describe('The Heap object', () => {
       return {
         path: 'Basics::Foo',
         screen_name: 'Foo',
-      }
-    })
+      };
+    });
   });
 
   describe('track', () => {
@@ -64,7 +64,10 @@ describe('The Heap object', () => {
       expect(mockTrack.mock.calls.length).toBe(1);
       expect(mockTrack.mock.calls[0][0]).toBe('foo');
       expect(mockTrack.mock.calls[0][1]).toEqual(expectedProps);
-      expect(mockTrack.mock.calls[0][2]).toEqual({ path: 'Basics::Foo', screen_name: 'Foo' });
+      expect(mockTrack.mock.calls[0][2]).toEqual({
+        path: 'Basics::Foo',
+        screen_name: 'Foo',
+      });
     };
 
     it('works in the common case', () => {

--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { NativeModules } from 'react-native';
 
+import NavigationUtil from '../util/navigationUtil';
 import Heap from '../Heap';
+
+jest.mock('../util/navigationUtil');
 
 describe('The Heap object', () => {
   let mockTrack,
@@ -47,6 +50,13 @@ describe('The Heap object', () => {
 
     NativeModules.RNHeap.clearEventProperties.mockReset();
     mockClearEventProperties = NativeModules.RNHeap.clearEventProperties;
+
+    NavigationUtil.getScreenPropsForCurrentRoute.mockImplementation(() => {
+      return {
+        path: 'Basics::Foo',
+        screen_name: 'Foo',
+      }
+    })
   });
 
   describe('track', () => {
@@ -54,6 +64,7 @@ describe('The Heap object', () => {
       expect(mockTrack.mock.calls.length).toBe(1);
       expect(mockTrack.mock.calls[0][0]).toBe('foo');
       expect(mockTrack.mock.calls[0][1]).toEqual(expectedProps);
+      expect(mockTrack.mock.calls[0][2]).toEqual({ path: 'Basics::Foo', screen_name: 'Foo' });
     };
 
     it('works in the common case', () => {

--- a/js/util/__mocks__/navigationUtil.js
+++ b/js/util/__mocks__/navigationUtil.js
@@ -1,0 +1,3 @@
+const NavigationUtil = jest.genMockFromModule('./navigationUtil');
+
+export default NavigationUtil;


### PR DESCRIPTION
## Description
For manual track calls, include screen props (`screen_name`, `path`) as contextual source props.

## Test Plan
Updated existing tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (will be updated right before feature/rnfcl is merged into develop)
