### PR TITLE
[HEAP-11558] Use Android Framework track methods

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,9 @@ buildscript {
     repositories {
         jcenter()
         google()
+        maven {
+            url 'https://heap-maven-public.s3.amazonaws.com/android-testing'
+        }
     }
 
     dependencies {
@@ -76,10 +79,13 @@ android {
 repositories {
     jcenter()
     google()
+    maven {
+        url 'https://heap-maven-public.s3.amazonaws.com/android-testing'
+    }
 }
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    api 'com.heapanalytics.android:heap-android-client:1.1.0'
+    api 'com.heapanalytics.android:heap-android-client:1.3.0-SNAPSHOT'
 }
 

--- a/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
+++ b/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
@@ -96,15 +96,11 @@ public class RNHeapLibraryModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void autocaptureEvent(String event, ReadableMap payload) {
-    // :TODO: (jmtaber129): Update this to look like:
-    // Heap.track(event, convertToStringMap(payload), "react_native").
-    Heap.track(event, convertToStringMap(payload));
+    HeapImpl.frameworkAutocaptureEvent(event, "react_native", convertToStringMap(payload));
   }
 
   @ReactMethod
   public void manuallyTrackEvent(String event, ReadableMap payload, ReadableMap contextualProps) {
-    // :TODO: (jmtaber129): Update this to look like:
-    // Heap.track(event, convertToStringMap(payload), "react_native", contextualProps).
-    Heap.track(event, convertToStringMap(payload));
+    HeapImpl.frameworkTrack(event, convertToStringMap(payload), "react_native", convertToStringMap(contextualProps));
   }
 }

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -199,6 +199,14 @@ describe('Basic React Native and Interaction Support', () => {
             sourceCustomEvent: {
               name: 'pressInTestEvent1',
               sourceName: 'react_native',
+              sourceProperties: {
+                path: {
+                  string: 'Basics',
+                },
+                screen_name: {
+                  string: 'Basics',
+                },
+              },
             },
           },
         },
@@ -223,6 +231,14 @@ describe('Basic React Native and Interaction Support', () => {
             sourceCustomEvent: {
               name: 'pressInTestEvent1',
               sourceName: 'react_native',
+              sourceProperties: {
+                path: {
+                  string: 'Basics',
+                },
+                screen_name: {
+                  string: 'Basics',
+                },
+              },
             },
           },
         }),
@@ -232,6 +248,14 @@ describe('Basic React Native and Interaction Support', () => {
             sourceCustomEvent: {
               name: 'pressInTestEvent2',
               sourceName: 'react_native',
+              sourceProperties: {
+                path: {
+                  string: 'Basics',
+                },
+                screen_name: {
+                  string: 'Basics',
+                },
+              },
             },
           },
         }),
@@ -248,6 +272,14 @@ describe('Basic React Native and Interaction Support', () => {
             sourceCustomEvent: {
               name: 'pressInTestEvent2',
               sourceName: 'react_native',
+              sourceProperties: {
+                path: {
+                  string: 'Basics',
+                },
+                screen_name: {
+                  string: 'Basics',
+                },
+              },
             },
           },
         },
@@ -268,6 +300,14 @@ describe('Basic React Native and Interaction Support', () => {
             sourceCustomEvent: {
               name: 'pressInTestEvent3',
               sourceName: 'react_native',
+              sourceProperties: {
+                path: {
+                  string: 'Basics',
+                },
+                screen_name: {
+                  string: 'Basics',
+                },
+              },
             },
           },
         },
@@ -288,6 +328,14 @@ describe('Basic React Native and Interaction Support', () => {
             sourceCustomEvent: {
               name: 'pressInTestEvent4',
               sourceName: 'react_native',
+              sourceProperties: {
+                path: {
+                  string: 'Basics',
+                },
+                screen_name: {
+                  string: 'Basics',
+                },
+              },
             },
           },
         },

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -195,13 +195,17 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAndroidEvent(
         {
           envId: '2084764307',
-          event: { custom: { name: 'pressInTestEvent1' } },
+          event: {
+            sourceCustomEvent: {
+              name: 'pressInTestEvent1',
+              sourceName: 'react_native',
+            },
+          },
         },
         event => {
           return (
             !_.has(event.properties, 'eventProp1') &&
-            !_.has(event.properties, 'eventProp2') &&
-            !_.has(event.properties, 'path')
+            !_.has(event.properties, 'eventProp2')
           );
         }
       );
@@ -215,11 +219,21 @@ describe('Basic React Native and Interaction Support', () => {
       const [[event1], [event2]] = await Promise.all([
         findAndroidEvent({
           envId: '2084764307',
-          event: { custom: { name: 'pressInTestEvent1' } },
+          event: {
+            sourceCustomEvent: {
+              name: 'pressInTestEvent1',
+              sourceName: 'react_native',
+            },
+          },
         }),
         findAndroidEvent({
           envId: '2084764307',
-          event: { custom: { name: 'pressInTestEvent2' } },
+          event: {
+            sourceCustomEvent: {
+              name: 'pressInTestEvent2',
+              sourceName: 'react_native',
+            },
+          },
         }),
       ]);
 
@@ -230,13 +244,17 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAndroidEvent(
         {
           envId: '2084764307',
-          event: { custom: { name: 'pressInTestEvent2' } },
+          event: {
+            sourceCustomEvent: {
+              name: 'pressInTestEvent2',
+              sourceName: 'react_native',
+            },
+          },
         },
         event => {
           return (
             _.has(event.properties, 'eventProp1') &&
-            _.has(event.properties, 'eventProp2') &&
-            !_.has(event.properties, 'path')
+            _.has(event.properties, 'eventProp2')
           );
         }
       );
@@ -246,13 +264,17 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAndroidEvent(
         {
           envId: '2084764307',
-          event: { custom: { name: 'pressInTestEvent3' } },
+          event: {
+            sourceCustomEvent: {
+              name: 'pressInTestEvent3',
+              sourceName: 'react_native',
+            },
+          },
         },
         event => {
           return (
             !_.has(event.properties, 'eventProp1') &&
-            _.has(event.properties, 'eventProp2') &&
-            !_.has(event.properties, 'path')
+            _.has(event.properties, 'eventProp2')
           );
         }
       );
@@ -262,13 +284,17 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAndroidEvent(
         {
           envId: '2084764307',
-          event: { custom: { name: 'pressInTestEvent4' } },
+          event: {
+            sourceCustomEvent: {
+              name: 'pressInTestEvent4',
+              sourceName: 'react_native',
+            },
+          },
         },
         event => {
           return (
             !_.has(event.properties, 'eventProp1') &&
-            !_.has(event.properties, 'eventProp2') &&
-            !_.has(event.properties, 'path')
+            !_.has(event.properties, 'eventProp2')
           );
         }
       );
@@ -306,11 +332,18 @@ describe('Basic React Native and Interaction Support', () => {
       const { err1, err2, res1, res2 } = await new Promise(resolve => {
         // Fetch a pre-resetIdentity event.
         testUtil.findAndroidEventInRedisRequests(
-          { event: { custom: { name: 'pressInTestEvent2' } } },
+          {
+            event: {
+              sourceCustomEvent: {
+                name: 'pressInTestEvent2',
+                sourceName: 'react_native',
+              },
+            },
+          },
           (err1, res1) => {
             // Fetch a post-resetIdentity event.
             testUtil.findAndroidEventInRedisRequests(
-              { event: { custom: { name: 'BASICS_SENTINEL' } } },
+              { event: { sourceCustomEvent: { name: 'BASICS_SENTINEL' } } },
               (err2, res2) => {
                 resolve({ err1, err2, res1, res2 });
               }

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -71,9 +71,10 @@ const assertAndroidAutotrackHierarchy = async (expectedName, expectedProps) => {
   return assertAndroidEvent({
     envId: HEAP_ENV_ID,
     event: {
-      custom: {
+      sourceEvent: {
         name: expectedName,
-        properties: _.mapValues(expectedProps, value => {
+        sourceName: 'react_native',
+        sourceProperties: _.mapValues(expectedProps, value => {
           return { string: value };
         }),
       },
@@ -115,9 +116,10 @@ const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
   return assertAndroidEvent({
     envId: HEAP_ENV_ID,
     event: {
-      custom: {
+      sourceEvent: {
         name: 'react_navigation_screenview',
-        properties: props,
+        sourceName: 'react_native',
+        sourceProperties: props,
       },
     },
   });
@@ -175,7 +177,7 @@ pollForSentinel = async (sentinelValue, timeout = 60000) => {
       const event = {
         envId: HEAP_ENV_ID,
         event: {
-          custom: {
+          sourceCustomEvent: {
             name: eventName,
           },
         },

--- a/examples/TestDriver/android/build.gradle
+++ b/examples/TestDriver/android/build.gradle
@@ -13,6 +13,9 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url 'https://heap-maven-public.s3.amazonaws.com/android-testing'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -32,6 +35,9 @@ allprojects {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
+        }
+        maven {
+            url 'https://heap-maven-public.s3.amazonaws.com/android-testing'
         }
     }
 }


### PR DESCRIPTION
## Description
* Switch the native Android methods the bridge uses from custom track to the framework track methods provided in https://github.com/heap/heap/pull/25075
* Updated tests to use the framework event format
* Changed the Heap native android SDK dependency to point to the `1.3.0-SNAPSHOT` version hosted on our S3 maven repo

~Note that this uses WIP changes from the android lib.  The android lib changes will need to be merged + released, and the react-native-heap lib's android dep will need to be upgraded in order for this to work.~

## Test Plan
Updated existing detox test cases

## Checklist
- [X] Detox tests pass (only Heap employees are able run these) ~- Tests pass, but with uncommitted changes that point the native Heap android lib dependency at local changes currently under review~
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (will be updated right before feature/rnfcl is merged into develop)
