### PR TITLE
[HEAP-11507] Revise additional names of event types + props

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -338,6 +338,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
+        is_long_press: '0',
+        touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         path: 'Basics',
       });
@@ -349,6 +351,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
+        is_long_press: '0',
+        touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         path: 'Basics',
       });
@@ -360,6 +364,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
+        is_long_press: '0',
+        touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         path: 'Basics',
       });
@@ -371,6 +377,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
+        is_long_press: '0',
+        touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         path: 'Basics',
       });

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -338,7 +338,7 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
-        is_long_press: '0',
+        is_long_press: rnTestUtil.getPlatformBoolean(false),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         path: 'Basics',
@@ -351,8 +351,8 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
-        is_long_press: '0',
-        touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
+        is_long_press: rnTestUtil.getPlatformBoolean(false),
+        touch_state: 'RESPONDER_INACTIVE_PRESS_IN',
         screen_name: 'Basics',
         path: 'Basics',
       });
@@ -364,7 +364,7 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
-        is_long_press: '0',
+        is_long_press: rnTestUtil.getPlatformBoolean(false),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         path: 'Basics',
@@ -377,7 +377,7 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
-        is_long_press: '0',
+        is_long_press: rnTestUtil.getPlatformBoolean(true),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         path: 'Basics',

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -17,6 +17,13 @@ const waitIfIos = async () => {
   }
 };
 
+const getPlatformBoolean = (boolean) => {
+  if (device.getPlatform() === 'ios') {
+    return boolean ? '1' : '0';
+  }
+  return boolean.toString();
+}
+
 const flushAllRedis = nodeUtil.promisify(done =>
   db.orm.connection.sharedRedis().flushall(done)
 );
@@ -215,5 +222,6 @@ module.exports = {
   assertNavigationEvent,
   pollForSentinel,
   waitIfIos,
+  getPlatformBoolean,
   flushAllRedis,
 };

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -17,12 +17,12 @@ const waitIfIos = async () => {
   }
 };
 
-const getPlatformBoolean = (boolean) => {
+const getPlatformBoolean = boolean => {
   if (device.getPlatform() === 'ios') {
     return boolean ? '1' : '0';
   }
   return boolean.toString();
-}
+};
 
 const flushAllRedis = nodeUtil.promisify(done =>
   db.orm.connection.sharedRedis().flushall(done)

--- a/js/autotrack/touchables.js
+++ b/js/autotrack/touchables.js
@@ -14,8 +14,8 @@ export const autotrackPress = track => (eventType, componentThis, event) => {
     componentThis.state.touchable &&
     componentThis.state.touchable.touchState;
 
-  autotrackProps.touchState = touchState;
-  autotrackProps.isLongPress = eventType === 'touchableHandleLongPress';
+  autotrackProps.touch_state = touchState;
+  autotrackProps.is_long_press = eventType === 'touchableHandleLongPress';
 
   track('touch', autotrackProps);
 };


### PR DESCRIPTION
## Description
This fixes a few names that were missed in https://github.com/heap/react-native-heap/pull/149

## Test Plan
Added assertions to detox test cases

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (will be updated right before feature/rnfcl is merged into develop)
