### PR TITLE
Rename conflicting field names

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -417,7 +417,7 @@ describe('Basic React Native and Interaction Support', () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableOpacity;[testID=touchableOpacityText];|`;
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
         is_long_press: rnTestUtil.getPlatformBoolean(false),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
@@ -430,7 +430,7 @@ describe('Basic React Native and Interaction Support', () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableHighlight;[testID=touchableHighlightText];|`;
       const expectedTargetText = 'Touchable Highlight';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
         is_long_press: rnTestUtil.getPlatformBoolean(false),
         touch_state: 'RESPONDER_INACTIVE_PRESS_IN',
@@ -443,7 +443,7 @@ describe('Basic React Native and Interaction Support', () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|`;
       const expectedTargetText = 'Touchable Without Feedback';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
         is_long_press: rnTestUtil.getPlatformBoolean(false),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
@@ -456,7 +456,7 @@ describe('Basic React Native and Interaction Support', () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|`;
       const expectedTargetText = 'Touchable Native Feedback';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
         is_long_press: rnTestUtil.getPlatformBoolean(true),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
@@ -468,7 +468,7 @@ describe('Basic React Native and Interaction Support', () => {
     it("should autotrack 'Switch's", async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}Switch;[testID=switch];|`;
       await rnTestUtil.assertAutotrackHierarchy('change', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
         path: 'Basics',
       });
@@ -477,7 +477,7 @@ describe('Basic React Native and Interaction Support', () => {
     it("should autotrack NativeBase 'Switch's", async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}StyledComponent;[testID=nbSwitch];|Switch;[testID=nbSwitch];|Switch;[testID=nbSwitch];|`;
       await rnTestUtil.assertAutotrackHierarchy('change', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
         path: 'Basics',
       });
@@ -486,7 +486,7 @@ describe('Basic React Native and Interaction Support', () => {
     it('should autotrack ScrollView paging', async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}FlatList;[testID=scrollView];|VirtualizedList;[testID=scrollView];|ScrollView;[testID=scrollView];|`;
       await rnTestUtil.assertAutotrackHierarchy('scroll_view_page', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         page_index: '1',
         screen_name: 'Basics',
         path: 'Basics',
@@ -496,7 +496,7 @@ describe('Basic React Native and Interaction Support', () => {
     it('should autotrack TextInput edits', async () => {
       const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}MyTextInput;[testID=textInput];|TextInput;[testID=textInput];|`;
       await rnTestUtil.assertAutotrackHierarchy('text_edit', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         placeholder_text: 'foo placeholder',
         screen_name: 'Basics',
         path: 'Basics',

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -77,7 +77,7 @@ describe('Basic React Native and Interaction Support', () => {
         {
           a: '2084764307',
           t: 'pressInTestEvent1',
-          sprops: ['path', 'Basics', 'screen_name', 'Basics'],
+          sprops: ['screen_path', 'Basics', 'screen_name', 'Basics'],
         },
         event => {
           return !(
@@ -93,7 +93,7 @@ describe('Basic React Native and Interaction Support', () => {
         {
           a: '2084764307',
           t: 'pressInTestEvent2',
-          sprops: ['path', 'Basics', 'screen_name', 'Basics'],
+          sprops: ['screen_path', 'Basics', 'screen_name', 'Basics'],
         },
         event => {
           return (
@@ -109,7 +109,7 @@ describe('Basic React Native and Interaction Support', () => {
         {
           a: '2084764307',
           t: 'pressInTestEvent3',
-          sprops: ['path', 'Basics', 'screen_name', 'Basics'],
+          sprops: ['screen_path', 'Basics', 'screen_name', 'Basics'],
         },
         event => {
           return (
@@ -125,7 +125,7 @@ describe('Basic React Native and Interaction Support', () => {
         {
           a: '2084764307',
           t: 'pressInTestEvent4',
-          sprops: ['path', 'Basics', 'screen_name', 'Basics'],
+          sprops: ['screen_path', 'Basics', 'screen_name', 'Basics'],
         },
         event => {
           return !(
@@ -200,7 +200,7 @@ describe('Basic React Native and Interaction Support', () => {
               name: 'pressInTestEvent1',
               sourceName: 'react_native',
               sourceProperties: {
-                path: {
+                screen_path: {
                   string: 'Basics',
                 },
                 screen_name: {
@@ -232,7 +232,7 @@ describe('Basic React Native and Interaction Support', () => {
               name: 'pressInTestEvent1',
               sourceName: 'react_native',
               sourceProperties: {
-                path: {
+                screen_path: {
                   string: 'Basics',
                 },
                 screen_name: {
@@ -249,7 +249,7 @@ describe('Basic React Native and Interaction Support', () => {
               name: 'pressInTestEvent2',
               sourceName: 'react_native',
               sourceProperties: {
-                path: {
+                screen_path: {
                   string: 'Basics',
                 },
                 screen_name: {
@@ -273,7 +273,7 @@ describe('Basic React Native and Interaction Support', () => {
               name: 'pressInTestEvent2',
               sourceName: 'react_native',
               sourceProperties: {
-                path: {
+                screen_path: {
                   string: 'Basics',
                 },
                 screen_name: {
@@ -301,7 +301,7 @@ describe('Basic React Native and Interaction Support', () => {
               name: 'pressInTestEvent3',
               sourceName: 'react_native',
               sourceProperties: {
-                path: {
+                screen_path: {
                   string: 'Basics',
                 },
                 screen_name: {
@@ -329,7 +329,7 @@ describe('Basic React Native and Interaction Support', () => {
               name: 'pressInTestEvent4',
               sourceName: 'react_native',
               sourceProperties: {
-                path: {
+                screen_path: {
                   string: 'Basics',
                 },
                 screen_name: {
@@ -422,7 +422,7 @@ describe('Basic React Native and Interaction Support', () => {
         is_long_press: rnTestUtil.getPlatformBoolean(false),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
-        path: 'Basics',
+        screen_path: 'Basics',
       });
     });
 
@@ -435,7 +435,7 @@ describe('Basic React Native and Interaction Support', () => {
         is_long_press: rnTestUtil.getPlatformBoolean(false),
         touch_state: 'RESPONDER_INACTIVE_PRESS_IN',
         screen_name: 'Basics',
-        path: 'Basics',
+        screen_path: 'Basics',
       });
     });
 
@@ -448,7 +448,7 @@ describe('Basic React Native and Interaction Support', () => {
         is_long_press: rnTestUtil.getPlatformBoolean(false),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
-        path: 'Basics',
+        screen_path: 'Basics',
       });
     });
 
@@ -461,7 +461,7 @@ describe('Basic React Native and Interaction Support', () => {
         is_long_press: rnTestUtil.getPlatformBoolean(true),
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
-        path: 'Basics',
+        screen_path: 'Basics',
       });
     });
 
@@ -470,7 +470,7 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('change', {
         rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
-        path: 'Basics',
+        screen_path: 'Basics',
       });
     });
 
@@ -479,7 +479,7 @@ describe('Basic React Native and Interaction Support', () => {
       await rnTestUtil.assertAutotrackHierarchy('change', {
         rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
-        path: 'Basics',
+        screen_path: 'Basics',
       });
     });
 
@@ -489,7 +489,7 @@ describe('Basic React Native and Interaction Support', () => {
         rn_hierarchy: expectedHierarchy,
         page_index: '1',
         screen_name: 'Basics',
-        path: 'Basics',
+        screen_path: 'Basics',
       });
     });
 
@@ -499,7 +499,7 @@ describe('Basic React Native and Interaction Support', () => {
         rn_hierarchy: expectedHierarchy,
         placeholder_text: 'foo placeholder',
         screen_name: 'Basics',
-        path: 'Basics',
+        screen_path: 'Basics',
       });
     });
   });

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -55,21 +55,21 @@ describe('HeapIgnore', () => {
   it('should ignore the inner hierarchy', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
-      hierarchy: expectedHierarchy,
+      rn_hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore props and target text', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|TouchableOpacity;|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
-      hierarchy: expectedHierarchy,
+      rn_hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore props', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|TouchableOpacity;|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
-      hierarchy: expectedHierarchy,
+      rn_hierarchy: expectedHierarchy,
       target_text: 'Foobar',
     });
   });
@@ -77,14 +77,14 @@ describe('HeapIgnore', () => {
   it('should allow everything except target text HOC', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}withHeapIgnore(TouchableOpacity);[testID=allowedAllPropsHoc];|HeapIgnore;|TouchableOpacity;[testID=allowedAllPropsHoc];|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
-      hierarchy: expectedHierarchy,
+      rn_hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore target text', async () => {
     const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnoreTargetText;|HeapIgnore;|TouchableOpacity;[testID=ignoredTargetText];|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
-      hierarchy: expectedHierarchy,
+      rn_hierarchy: expectedHierarchy,
     });
   });
 });

--- a/e2e/nav.spec.js
+++ b/e2e/nav.spec.js
@@ -73,17 +73,17 @@ describe('Navigation', () => {
     it('tracks events with screen name props', async () => {
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         screen_name: 'Base',
-        path: 'Nav::MainStack::Base',
+        screen_path: 'Nav::MainStack::Base',
       });
 
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         screen_name: 'StackCard',
-        path: 'Nav::MainStack::StackCard',
+        screen_path: 'Nav::MainStack::StackCard',
       });
 
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         screen_name: 'ModalStack',
-        path: 'Nav::ModalStack',
+        screen_path: 'Nav::ModalStack',
       });
     });
 

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -52,7 +52,7 @@ describe('Property Extraction in Hierarchies', () => {
           ? 'testButtonTitle1'
           : 'TESTBUTTONTITLE1';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
       });
     });
@@ -64,7 +64,7 @@ describe('Property Extraction in Hierarchies', () => {
           ? 'testButtonTitle2'
           : 'TESTBUTTONTITLE2';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
       });
     });
@@ -78,7 +78,7 @@ describe('Property Extraction in Hierarchies', () => {
           ? 'testButtonTitle3'
           : 'TESTBUTTONTITLE3';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
-        hierarchy: expectedHierarchy,
+        rn_hierarchy: expectedHierarchy,
         target_text: expectedTargetText,
       });
     });

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -107,7 +107,7 @@ const assertAutotrackHierarchy = async (expectedName, expectedProps) => {
 
 const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
   const commonProps = {
-    path: {
+    screen_path: {
       string: expectedPath,
     },
   };
@@ -133,7 +133,7 @@ const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
 };
 
 const assertIosNavigationEvent = async (expectedPath, expectedType) => {
-  const commonProps = ['path', expectedPath];
+  const commonProps = ['screen_path', expectedPath];
   const props = expectedType
     ? [...commonProps, 'action', expectedType]
     : commonProps;

--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -53,7 +53,7 @@ describe('The Heap object', () => {
 
     NavigationUtil.getScreenPropsForCurrentRoute.mockImplementation(() => {
       return {
-        path: 'Basics::Foo',
+        screen_path: 'Basics::Foo',
         screen_name: 'Foo',
       };
     });
@@ -65,7 +65,7 @@ describe('The Heap object', () => {
       expect(mockTrack.mock.calls[0][0]).toBe('foo');
       expect(mockTrack.mock.calls[0][1]).toEqual(expectedProps);
       expect(mockTrack.mock.calls[0][2]).toEqual({
-        path: 'Basics::Foo',
+        screen_path: 'Basics::Foo',
         screen_name: 'Foo',
       });
     };

--- a/js/autotrack/__tests__/heapIgnore.spec.js
+++ b/js/autotrack/__tests__/heapIgnore.spec.js
@@ -51,7 +51,7 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         target_text: 'foobar',
-        hierarchy:
+        rn_hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|Text;[testID=targetElement];|',
       });
     });
@@ -85,7 +85,8 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         target_text: 'foobar',
-        hierarchy: 'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|',
+        rn_hierarchy:
+          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|',
       });
     });
 
@@ -107,7 +108,7 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         target_text: 'foobar',
-        hierarchy:
+        rn_hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;|',
       });
     });
@@ -129,7 +130,7 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        hierarchy:
+        rn_hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;[testID=targetElement];|',
       });
     });
@@ -155,7 +156,7 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         target_text: 'foobar',
-        hierarchy:
+        rn_hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;[testID=targetElement];|',
       });
     });
@@ -186,7 +187,7 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        hierarchy:
+        rn_hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|BarFunction;|HeapIgnore;|',
       });
     });
@@ -206,7 +207,7 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        hierarchy:
+        rn_hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|withHeapIgnore(Text);[testID=targetElement];|HeapIgnore;|Text;|',
       });
     });
@@ -224,7 +225,7 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
-        hierarchy:
+        rn_hierarchy:
           'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnoreTargetText;|HeapIgnore;|Text;[testID=targetElement];|',
       });
     });

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -16,7 +16,7 @@ interface Component extends ReactComponent {
 
 // Base properties for autotracked events.
 interface AutotrackProps {
-  hierarchy: string;
+  rn_hierarchy: string;
   target_text?: string;
   path?: string;
   screen_name?: string;
@@ -73,7 +73,7 @@ export const getBaseComponentProps: (
   const screenProps = NavigationUtil.getScreenPropsForCurrentRoute();
 
   const autotrackProps: AutotrackProps = {
-    hierarchy,
+    rn_hierarchy: hierarchy,
     ...screenProps,
   };
 

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -18,7 +18,7 @@ interface Component extends ReactComponent {
 interface AutotrackProps {
   rn_hierarchy: string;
   target_text?: string;
-  path?: string;
+  screen_path?: string;
   screen_name?: string;
 }
 

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -23,12 +23,12 @@ export const withReactNavigationAutotrack = track => AppContainer => {
     }
 
     trackInitialRoute() {
-      const { path: initialPageviewPath } = NavigationUtil.getActiveRouteProps(
-        this.topLevelNavigator.state.nav
-      );
+      const {
+        screen_path: initialPageviewPath,
+      } = NavigationUtil.getActiveRouteProps(this.topLevelNavigator.state.nav);
 
       track(EVENT_TYPE, {
-        path: initialPageviewPath,
+        screen_path: initialPageviewPath,
         action: INITIAL_ROUTE_TYPE,
       });
     }
@@ -65,14 +65,14 @@ export const withReactNavigationAutotrack = track => AppContainer => {
           })}
           onNavigationStateChange={bailOnError((prev, next, action) => {
             const {
-              path: prevScreenRoute,
+              screen_path: prevScreenRoute,
             } = NavigationUtil.getActiveRouteProps(prev);
             const {
-              path: nextScreenRoute,
+              screen_path: nextScreenRoute,
             } = NavigationUtil.getActiveRouteProps(next);
             if (prevScreenRoute !== nextScreenRoute) {
               track(EVENT_TYPE, {
-                path: nextScreenRoute,
+                screen_path: nextScreenRoute,
                 action: action.type,
               });
             }

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -7,7 +7,7 @@ export default class NavigationUtil {
   }
 
   static getScreenPropsForCurrentRoute(): {
-    path: string;
+    screen_path: string;
     screen_name: string;
   } | null {
     if (
@@ -28,10 +28,10 @@ export default class NavigationUtil {
   // :TODO: (jmtaber129): Add type for navigationState.
   static getActiveRouteProps(
     navigationState: any
-  ): { path: string; screen_name: string } {
+  ): { screen_path: string; screen_name: string } {
     const paths = this.getActiveRouteNames(navigationState);
     return {
-      path: paths.join('::'),
+      screen_path: paths.join('::'),
       screen_name: paths[paths.length - 1],
     };
   }


### PR DESCRIPTION
## Description
Renames hierarchy to react_hierarchy and path to screen_path due to conflicts with the web `hierarchy` and `path` properties on the frontend.  This was originally expected to be a non-issue, since these fields would be from RN, and the web fields would be from web, but this doesn't seem to be the case.

## Test Plan
Updated test cases

## Checklist
- [X] Detox tests pass
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (n/a)
