### PR TITLE
[HEAP-11566] Bump android to the released v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ __BEGIN_UNRELEASED__
 ### Added
 ### Changed
 - Updated the way events are sent to the Heap backend to allow for first-class support of React Native as a library.  See <TODO: upgrade guide link> for details.
+- Upgraded the native Android Heap SDK to v1.3.0.
 - Updated higher-order components to use display name conventions (described [here](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)).
 
 ### Deprecated

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,9 +39,6 @@ buildscript {
     repositories {
         jcenter()
         google()
-        maven {
-            url 'https://heap-maven-public.s3.amazonaws.com/android-testing'
-        }
     }
 
     dependencies {
@@ -79,13 +76,10 @@ android {
 repositories {
     jcenter()
     google()
-    maven {
-        url 'https://heap-maven-public.s3.amazonaws.com/android-testing'
-    }
 }
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    api 'com.heapanalytics.android:heap-android-client:1.3.0-SNAPSHOT'
+    api 'com.heapanalytics.android:heap-android-client:1.3.0'
 }
 

--- a/examples/TestDriver/android/build.gradle
+++ b/examples/TestDriver/android/build.gradle
@@ -7,15 +7,12 @@ buildscript {
         compileSdkVersion = 27
         targetSdkVersion = 26
         supportLibVersion = "27.1.1"
-        ext.heapVersion = '0.7.4'
+        ext.heapVersion = '1.3.0'
         ext.kotlinVersion = '1.3.0'
     }
     repositories {
         google()
         jcenter()
-        maven {
-            url 'https://heap-maven-public.s3.amazonaws.com/android-testing'
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
@@ -35,9 +32,6 @@ allprojects {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
-        }
-        maven {
-            url 'https://heap-maven-public.s3.amazonaws.com/android-testing'
         }
     }
 }


### PR DESCRIPTION
## Description
Bump the android dep to the actual release of v1.3.0

## Test Plan
Ran tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
