### PR TITLE
Update React Hierarchy Format

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -7,7 +7,7 @@ testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
 const BASICS_PAGE_TOP_HIERARCHY =
-  'AppContainer;|App;|Provider;|withReactNavigationAutotrack(NavigationContainer);|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=Basics];|SceneView;|Connect(BasicsPage);|BasicsPage;|ScrollView;[testID=scrollContainer];|';
+  '@AppContainer;|@App;|@Provider;|@withReactNavigationAutotrack(NavigationContainer);|@NavigationContainer;|@Navigator;|@NavigationView;|@TabNavigationView;|@ScreenContainer;|@ResourceSavingScene;[key=Basics];|@SceneView;|@Connect(BasicsPage);|@BasicsPage;|@ScrollView;[testID=scrollContainer];|';
 
 const doTestActions = async () => {
   // Open the Basics tab in the tab navigator.
@@ -414,7 +414,7 @@ describe('Basic React Native and Interaction Support', () => {
 
   describe('Autotrack', () => {
     it("should autotrack 'TouchableOpacity's", async () => {
-      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableOpacity;[testID=touchableOpacityText];|`;
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}@TouchableOpacity;[testID=touchableOpacityText];|`;
       const expectedTargetText = 'Touchable Opacity Foo';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         rn_hierarchy: expectedHierarchy,
@@ -427,7 +427,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it("should autotrack 'TouchableHighlight's", async () => {
-      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableHighlight;[testID=touchableHighlightText];|`;
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}@TouchableHighlight;[testID=touchableHighlightText];|`;
       const expectedTargetText = 'Touchable Highlight';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         rn_hierarchy: expectedHierarchy,
@@ -440,7 +440,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it("should autotrack 'TouchableWithoutFeedback's", async () => {
-      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|`;
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}@TouchableWithoutFeedback;[testID=touchableWithoutFeedbackText];|`;
       const expectedTargetText = 'Touchable Without Feedback';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         rn_hierarchy: expectedHierarchy,
@@ -453,7 +453,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it(":android: should autotrack 'TouchableNativeFeedback's", async () => {
-      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|`;
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}@TouchableNativeFeedback;[testID=touchableNativeFeedbackText];|`;
       const expectedTargetText = 'Touchable Native Feedback';
       await rnTestUtil.assertAutotrackHierarchy('touch', {
         rn_hierarchy: expectedHierarchy,
@@ -466,7 +466,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it("should autotrack 'Switch's", async () => {
-      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}Switch;[testID=switch];|`;
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}@Switch;[testID=switch];|`;
       await rnTestUtil.assertAutotrackHierarchy('change', {
         rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
@@ -475,7 +475,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it("should autotrack NativeBase 'Switch's", async () => {
-      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}StyledComponent;[testID=nbSwitch];|Switch;[testID=nbSwitch];|Switch;[testID=nbSwitch];|`;
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}@StyledComponent;[testID=nbSwitch];|@Switch;[testID=nbSwitch];|@Switch;[testID=nbSwitch];|`;
       await rnTestUtil.assertAutotrackHierarchy('change', {
         rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
@@ -484,7 +484,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it('should autotrack ScrollView paging', async () => {
-      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}FlatList;[testID=scrollView];|VirtualizedList;[testID=scrollView];|ScrollView;[testID=scrollView];|`;
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}@FlatList;[testID=scrollView];|@VirtualizedList;[testID=scrollView];|@ScrollView;[testID=scrollView];|`;
       await rnTestUtil.assertAutotrackHierarchy('scroll_view_page', {
         rn_hierarchy: expectedHierarchy,
         page_index: '1',
@@ -494,7 +494,7 @@ describe('Basic React Native and Interaction Support', () => {
     });
 
     it('should autotrack TextInput edits', async () => {
-      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}MyTextInput;[testID=textInput];|TextInput;[testID=textInput];|`;
+      const expectedHierarchy = `${BASICS_PAGE_TOP_HIERARCHY}@MyTextInput;[testID=textInput];|@TextInput;[testID=textInput];|`;
       await rnTestUtil.assertAutotrackHierarchy('text_edit', {
         rn_hierarchy: expectedHierarchy,
         placeholder_text: 'foo placeholder',

--- a/e2e/heapIgnore.spec.js
+++ b/e2e/heapIgnore.spec.js
@@ -7,7 +7,7 @@ testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
 
 const HEAPIGNORE_PAGE_TOP_HIERARCHY =
-  'AppContainer;|App;|Provider;|withReactNavigationAutotrack(NavigationContainer);|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=HeapIgnore];|SceneView;|HeapIgnorePage;|';
+  '@AppContainer;|@App;|@Provider;|@withReactNavigationAutotrack(NavigationContainer);|@NavigationContainer;|@Navigator;|@NavigationView;|@TabNavigationView;|@ScreenContainer;|@ResourceSavingScene;[key=HeapIgnore];|@SceneView;|@HeapIgnorePage;|';
 
 const doTestActions = async () => {
   // Open the HeapIgnore tab in the tab navigator.
@@ -53,21 +53,21 @@ describe('HeapIgnore', () => {
   });
 
   it('should ignore the inner hierarchy', async () => {
-    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|`;
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}@HeapIgnore;|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
       rn_hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore props and target text', async () => {
-    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|TouchableOpacity;|`;
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}@HeapIgnore;|@TouchableOpacity;|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
       rn_hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore props', async () => {
-    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnore;|TouchableOpacity;|`;
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}@HeapIgnore;|@TouchableOpacity;|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
       rn_hierarchy: expectedHierarchy,
       target_text: 'Foobar',
@@ -75,14 +75,14 @@ describe('HeapIgnore', () => {
   });
 
   it('should allow everything except target text HOC', async () => {
-    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}withHeapIgnore(TouchableOpacity);[testID=allowedAllPropsHoc];|HeapIgnore;|TouchableOpacity;[testID=allowedAllPropsHoc];|`;
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}@withHeapIgnore(TouchableOpacity);[testID=allowedAllPropsHoc];|@HeapIgnore;|@TouchableOpacity;[testID=allowedAllPropsHoc];|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
       rn_hierarchy: expectedHierarchy,
     });
   });
 
   it('should ignore target text', async () => {
-    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}HeapIgnoreTargetText;|HeapIgnore;|TouchableOpacity;[testID=ignoredTargetText];|`;
+    const expectedHierarchy = `${HEAPIGNORE_PAGE_TOP_HIERARCHY}@HeapIgnoreTargetText;|@HeapIgnore;|@TouchableOpacity;[testID=ignoredTargetText];|`;
     await rnTestUtil.assertAutotrackHierarchy('touch', {
       rn_hierarchy: expectedHierarchy,
     });

--- a/e2e/propExtraction.spec.js
+++ b/e2e/propExtraction.spec.js
@@ -9,7 +9,7 @@ const IOS_BUTTON_SUFFIX = 'TouchableOpacity;';
 const ANDROID_BUTTON_SUFFIX = 'TouchableNativeFeedback;';
 
 const PROPEXTRACTION_PAGE_TOP_HIERARCHY =
-  'AppContainer;|App;|Provider;|withReactNavigationAutotrack(NavigationContainer);|NavigationContainer;|Navigator;|NavigationView;|TabNavigationView;|ScreenContainer;|ResourceSavingScene;[key=PropExtraction];|SceneView;|PropExtraction;|';
+  '@AppContainer;|@App;|@Provider;|@withReactNavigationAutotrack(NavigationContainer);|@NavigationContainer;|@Navigator;|@NavigationView;|@TabNavigationView;|@ScreenContainer;|@ResourceSavingScene;[key=PropExtraction];|@SceneView;|@PropExtraction;|';
 
 const doTestActions = async () => {
   // Open the PropExtraction tab in the tab navigator.
@@ -46,7 +46,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with class components', async () => {
-      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}Container1;[custom1=customProp1];|Button;[testID=button1];[title=testButtonTitle1];|${buttonSuffix}[testID=button1];|`;
+      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}@Container1;[custom1=customProp1];|@Button;[testID=button1];[title=testButtonTitle1];|@${buttonSuffix}[testID=button1];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle1'
@@ -58,7 +58,7 @@ describe('Property Extraction in Hierarchies', () => {
     });
 
     it('works with stateless components', async () => {
-      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}Container2;[custom2=customProp2];|Button;[testID=button2];[title=testButtonTitle2];|${buttonSuffix}[testID=button2];|`;
+      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}@Container2;[custom2=customProp2];|@Button;[testID=button2];[title=testButtonTitle2];|@${buttonSuffix}[testID=button2];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle2'
@@ -72,7 +72,7 @@ describe('Property Extraction in Hierarchies', () => {
     it('properly excludes properties', async () => {
       // The important thing for this test is that the first mention of 'Button' does NOT include the title property.
       // This is because the first one is a custom class that specifically excludes (while the second one is the built-in Button.)
-      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}Button;|Button;[testID=button3];[title=testButtonTitle3];|${buttonSuffix}[testID=button3];|`;
+      const expectedHierarchy = `${PROPEXTRACTION_PAGE_TOP_HIERARCHY}@Button;|@Button;[testID=button3];[title=testButtonTitle3];|@${buttonSuffix}[testID=button3];|`;
       const expectedTargetText =
         device.getPlatform() === 'ios'
           ? 'testButtonTitle3'

--- a/js/autotrack/__tests__/heapIgnore.spec.js
+++ b/js/autotrack/__tests__/heapIgnore.spec.js
@@ -52,7 +52,7 @@ describe('Common autotrack utils', () => {
       expect(normalProps).toEqual({
         target_text: 'foobar',
         rn_hierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|Text;[testID=targetElement];|',
+          '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@Text;[testID=targetElement];|',
       });
     });
 
@@ -86,7 +86,7 @@ describe('Common autotrack utils', () => {
       expect(normalProps).toEqual({
         target_text: 'foobar',
         rn_hierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|',
+          '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|',
       });
     });
 
@@ -109,7 +109,7 @@ describe('Common autotrack utils', () => {
       expect(normalProps).toEqual({
         target_text: 'foobar',
         rn_hierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;|',
+          '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;|',
       });
     });
 
@@ -131,7 +131,7 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         rn_hierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;[testID=targetElement];|',
+          '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;[testID=targetElement];|',
       });
     });
 
@@ -157,7 +157,7 @@ describe('Common autotrack utils', () => {
       expect(normalProps).toEqual({
         target_text: 'foobar',
         rn_hierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|Text;[testID=targetElement];|',
+          '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;[testID=targetElement];|',
       });
     });
 
@@ -188,7 +188,7 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         rn_hierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnore;|BarFunction;|HeapIgnore;|',
+          '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@BarFunction;|@HeapIgnore;|',
       });
     });
 
@@ -208,7 +208,7 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         rn_hierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|withHeapIgnore(Text);[testID=targetElement];|HeapIgnore;|Text;|',
+          '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@withHeapIgnore(Text);[testID=targetElement];|@HeapIgnore;|@Text;|',
       });
     });
 
@@ -226,7 +226,7 @@ describe('Common autotrack utils', () => {
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
         rn_hierarchy:
-          'WrapperComponent;|Foo;|BarClass;|BarFunction;|HeapIgnoreTargetText;|HeapIgnore;|Text;[testID=targetElement];|',
+          '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnoreTargetText;|@HeapIgnore;|@Text;[testID=targetElement];|',
       });
     });
 

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -168,9 +168,9 @@ const getHierarchyStringFromTraversal: (
         // current subhierarchy, return an empty string for the current component.
         currElementString = '';
       } else if (!currentHeapIgnoreProps.allowAllProps) {
-        currElementString = `${element.elementName};|`;
+        currElementString = `@${element.elementName};|`;
       } else {
-        currElementString = `${element.elementName};${element.propsString}|`;
+        currElementString = `@${element.elementName};${element.propsString}|`;
       }
 
       // Doing this at the end allows us to capture HeapIgnore components.


### PR DESCRIPTION
## Description
Update the hierarchy format to include an `@` before the component name.  This is what web, android, and ios do for hierarchies, and is required if we want to enable the `hier` operator (i.e. CSS-style matchers) in event definitions in the UI.

This _may_ be a breaking change for some event definitions, but only in the sense that the string used for matching might need to be different; event definitions will be broken and will need to be updated as part of an RNFCL upgrade anyway.  However, instead of being able to copy-paste a "touchableHierarchy contains `MyComponent;|MyOtherComponent`", users would need to manually update the string to `@MyComponent;|@MyOtherComponent` if using "React Native Hierarchy contains ...", or `MyComponent MyOtherComponent` (preferred) if using the target field (which uses the `hier` op).

**Open Question**: Do we want to move the `testID` prop (e.g. `MyComponent;[testID=foo];[bar=asdf];|`) to the place of the ID (e.g. `MyComponent;#foo;[bar=asdf];|`)?
* Answer: No for now.  We should look more at how widely `testID` is really used, and if there are other, better id-like things that this could be.

~NOTE: this PR needs a change of base once https://github.com/heap/react-native-heap/pull/155 lands~ Rebased

## Test Plan
Updated existing test cases

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (N/A)
