### PR TITLE
De-duplicate long press and short press events

### DIFF
--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -113,6 +113,9 @@ class BasicsPage extends Component {
           <Text>Touchable Opacity</Text>
           <Text>Foo</Text>
         </TouchableOpacity>
+        <TouchableOpacity testID="longPressedTouchableOpacity">
+          <Text>Touchable Opacity Long press</Text>
+        </TouchableOpacity>
         <TouchableHighlight testID="touchableHighlightText">
           <Text>Touchable Highlight</Text>
         </TouchableHighlight>

--- a/js/autotrack/touchables.js
+++ b/js/autotrack/touchables.js
@@ -14,6 +14,11 @@ export const autotrackPress = track => (eventType, componentThis, event) => {
     componentThis.state.touchable &&
     componentThis.state.touchable.touchState;
 
+  if (touchState === 'RESPONDER_ACTIVE_LONG_PRESS_IN') {
+    // We already captured this touch when the 'touchableHandleLongPress' hook fired, so don't capture this event.
+    return;
+  }
+
   autotrackProps.touch_state = touchState;
   autotrackProps.is_long_press = eventType === 'touchableHandleLongPress';
 


### PR DESCRIPTION
## Description
If a user long-presses a `Touchable` component, and the `Touchable` does not have an `onLongPress` handler, we’ll fire two touch events - one when the long press event fires (which happens after a brief delay), and one when the touch is released.

This used to matter less, since the long press and short press events had different types (`touchableHandlePress` and `touchableHandleLongPress`), so users would most likely just define their event on `touchableHandlePress` (thus reducing the likelihood of duplicated events manifesting in the virtual layer).

However, with the RNFCL changes, short and long presses are combined into a single touch event, with an `is_long_press` prop differentiating the two.  Since it would be unreasonable to expect all customers to specify a filter on `is_long_press` for _every_ event def, the probability of these manifesting as duplicate events in the virtual layer is a lot higher.

Check if the `touchState` represents a long press in the press handler, and ignore the event if so.  `touchState` only represents a long press _after_ the long press event fires, so this will only be the case with the normal press event that happens when the press is released.

## Test Plan
Added e2e test cases.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (N/A)
