### PR TITLE
[HEAP-12315] Delegate React Navigation onNavigationStateChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed React Navigation autocapture when [manual screen tracking](https://reactnavigation.org/docs/en/screen-tracking.html) is also used.
+
 ### Security
 __END_UNRELEASED__
 

--- a/examples/TestDriver/App.js
+++ b/examples/TestDriver/App.js
@@ -17,7 +17,9 @@ export default class App extends React.Component {
       <Provider store={store}>
         <TopNavigator
           ref={NavigationService.setTopLevelNavigator}
-          onNavigationStateChange={() => {}} // Checks that manually instrumenting screen tracking works.
+          // Check that manually instrumenting screen tracking doesn't break autocapture by passing in a no-op function as the
+          // 'onNavigationStateChange' handler.
+          onNavigationStateChange={() => {}}
         />
       </Provider>
     );

--- a/examples/TestDriver/App.js
+++ b/examples/TestDriver/App.js
@@ -15,7 +15,10 @@ export default class App extends React.Component {
   render() {
     return (
       <Provider store={store}>
-        <TopNavigator ref={NavigationService.setTopLevelNavigator} />
+        <TopNavigator
+          ref={NavigationService.setTopLevelNavigator}
+          onNavigationStateChange={() => {}} // Checks that manually instrumenting screen tracking works.
+        />
       </Provider>
     );
   }


### PR DESCRIPTION
## Description
Currently, if an `onNavigationStateChange` handler is passed to the React Navigation autocapture HOC, that handler will get called instead of the handler defined within the HOC.  So if someone is manually tracking screenviews using the [instructions provided by React Navigation](https://reactnavigation.org/docs/en/screen-tracking.html), our React Navigation autocapture won't work.

Delegate to the `onNavigationStateChange` passed to the HOC within the HOC's `onNavigationStateChange` handler.

## Test Plan
Changed test app to pass a `onNavigationStateChange` handler to the HOC.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
