### PR TITLE
[HEAP-11565] Vendor iOS v6.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ __BEGIN_UNRELEASED__
 ### Changed
 - Updated the way events are sent to the Heap backend to allow for first-class support of React Native as a library.  See <TODO: upgrade guide link> for details.
 - Upgraded the native Android Heap SDK to v1.3.0.
+- Upgraded vendored iOS Heap library to 6.5.1.
 - Updated higher-order components to use display name conventions (described [here](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)).
 
 ### Deprecated

--- a/ios/Vendor/Heap.h
+++ b/ios/Vendor/Heap.h
@@ -1,6 +1,6 @@
 //
 //  Heap.h
-//  Version 6.5.0
+//  Version 6.5.1
 //  Copyright (c) 2014 Heap Inc. All rights reserved.
 //
 

--- a/ios/Vendor/Heap.h
+++ b/ios/Vendor/Heap.h
@@ -1,6 +1,6 @@
 //
 //  Heap.h
-//  Version 6.5.0-alpha.1
+//  Version 6.5.0
 //  Copyright (c) 2014 Heap Inc. All rights reserved.
 //
 


### PR DESCRIPTION
## Description
Bump vendored iOS SDK to 6.5.1.

## Test Plan
Existing tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
