### PR TITLE
[HEAP-11800] Bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,22 @@ __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
 ### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+__END_UNRELEASED__
+
+## [0.9.0] - 2019-12-05
+
+### Changed
 - Updated the way events are sent to the Heap backend to allow for first-class support of React Native as a library.  See [the upgrade guide](https://docs.heap.io//docs/migrating-legacy-react-native-events-for-heap-090) for details.
 - Upgraded the native Android Heap SDK to v1.3.0.
 - Upgraded vendored iOS Heap library to 6.5.1.
 - Updated higher-order components to use display name conventions (described [here](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)).
 
-### Deprecated
-### Removed
 ### Fixed
 - Fixed React Navigation autocapture when [manual screen tracking](https://reactnavigation.org/docs/en/screen-tracking.html) is also used.
-
-### Security
-__END_UNRELEASED__
 
 ## [0.8.0] - 2019-08-26
 

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - glog (0.3.5)
   - React (0.57.5):
     - React/Core (= 0.57.5)
-  - react-native-heap (0.8.0):
+  - react-native-heap (0.9.0):
     - React
   - React/Core (0.57.5):
     - yoga (= 0.57.5.React)

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "./preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.8.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.9.0.tgz",
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
## Description
Bump version to 0.9.0

Currently blocked on updating the changelog with the upgrade guide.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
