### PR TITLE
Don't crash when Heap.track() is called and contextual props aren't present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed bug where app would crash when `Heap.track()` is called if React Navigation autocapture isn't set up. [#165](https://github.com/heap/react-native-heap/issues/165).
+
 ### Security
 __END_UNRELEASED__
 

--- a/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
+++ b/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
@@ -46,6 +46,10 @@ public class RNHeapLibraryModule extends ReactContextBaseJavaModule {
   }
 
   private static Map<String, String> convertToStringMap(ReadableMap readableMap) {
+    if (readableMap == null) {
+      return null;
+    }
+
     Map<String, String> stringMap = new HashMap<>();
     ReadableMapKeySetIterator mapIterator = readableMap.keySetIterator();
     while (mapIterator.hasNextKey()) {

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -35,7 +35,8 @@ const manualTrack = bailOnError((event, payload) => {
     // simulate a failure.
     const flatten = require('flat');
 
-    const contextualProps = NavigationUtil.getScreenPropsForCurrentRoute();
+    const contextualProps =
+      NavigationUtil.getScreenPropsForCurrentRoute() || {};
 
     payload = payload || {};
     RNHeap.manuallyTrackEvent(event, flatten(payload), contextualProps);


### PR DESCRIPTION
## Description
`NavigationUtil.getScreenPropsForCurrentRoute()` returns `null` if there are no contextual navigation props, but the `manuallyTrackEvent` in the Android `RNHeapLibraryModule` expects a non-null value.

Fixes https://github.com/heap/react-native-heap/issues/165.

## Test Plan
Manually repro'd bug by removing `withReactNavigationAutotrack` HOC wrapper, then manually tested after fixing bug.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
