### PR TITLE
Make e2e tests less flakey

### DIFF
--- a/e2e/mocha.opts
+++ b/e2e/mocha.opts
@@ -1,1 +1,1 @@
---recursive --timeout 120000
+--recursive --timeout 180000

--- a/examples/TestDriver/ios/TestDriver/AppDelegate.m
+++ b/examples/TestDriver/ios/TestDriver/AppDelegate.m
@@ -38,6 +38,7 @@
                                                       moduleName:@"TestDriver"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
+  // Suppress native iOS events to make pixels smaller, reducing flakiness.  See https://github.com/heap/react-native-heap/pull/144.
   [rootView setValue:@true forKey:@"heapIgnore"];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 

--- a/examples/TestDriver/ios/TestDriver/AppDelegate.m
+++ b/examples/TestDriver/ios/TestDriver/AppDelegate.m
@@ -38,6 +38,7 @@
                                                       moduleName:@"TestDriver"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
+  [rootView setValue:@true forKey:@"heapIgnore"];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];


### PR DESCRIPTION
## Description
Make detox e2e tests on iOS less flakey by ignoring native iOS events, and increasing the mocha timeout.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] ~If this is a bugfix/feature, the changelog has been updated~ (N/A)
