### PR TITLE
Vendor iOS 6.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ __BEGIN_UNRELEASED__
 ### Removed
 ### Fixed
 - Fixed bug where app would crash when `Heap.track()` is called if React Navigation autocapture isn't set up. [#165](https://github.com/heap/react-native-heap/issues/165).
+- Upgraded Heap iOS SDK dependency to 6.5.3 to pick up bug fixes since version 6.5.0.
 
 ### Security
 __END_UNRELEASED__

--- a/ios/Vendor/Heap.h
+++ b/ios/Vendor/Heap.h
@@ -1,6 +1,6 @@
 //
 //  Heap.h
-//  Version 6.5.1
+//  Version 6.5.3
 //  Copyright (c) 2014 Heap Inc. All rights reserved.
 //
 


### PR DESCRIPTION
## Description
Vendor v6.5.3 of the Heap iOS SDK dependency

## Test Plan
Ran detox tests for iOS

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
