### PR TITLE
Fix prop capture for react elements and circular refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ __BEGIN_UNRELEASED__
 - Fixed bug where app would crash when `Heap.track()` is called if React Navigation autocapture isn't set up. [#165](https://github.com/heap/react-native-heap/issues/165).
 - Strip additional special characters from props and component names to prevent hierarchy matching/parsing breakages.
 - Upgraded Heap iOS SDK dependency to 6.5.3 to pick up bug fixes since version 6.5.0.
+- Don't crash when capturing props with circular references or React JSX elements.
 
 ### Security
 __END_UNRELEASED__

--- a/js/autotrack/__tests__/common.spec.js
+++ b/js/autotrack/__tests__/common.spec.js
@@ -78,6 +78,26 @@ describe('Common autotrack utils', () => {
           '@WrapperComponent;|@MySpecialComponent;|@Text;[testID=targetElement];|',
       });
     });
+
+    it('Can capture props that are JSX components', () => {
+      const ListItem = props => {
+        return <View>{props.children}</View>;
+      };
+      const wrapper = mount(
+        <ListItem rightTitle={<Text>Foo</Text>}>
+          <Text testID="targetElement">{'foobar'}</Text>
+        </ListItem>
+      );
+      const normalComponent = wrapper
+        .find({ testID: 'targetElement' })
+        .filter(Text);
+      const normalProps = getBaseComponentProps(normalComponent.instance());
+      expect(normalProps).toEqual({
+        target_text: 'foobar',
+        rn_hierarchy:
+          '@WrapperComponent;|@ListItem;[rightTitle=React.element];|@Text;[testID=targetElement];|',
+      });
+    });
   });
 
   describe('HeapIgnore', () => {

--- a/js/util/__tests__/extractProps.spec.ts
+++ b/js/util/__tests__/extractProps.spec.ts
@@ -85,6 +85,15 @@ describe('Extracting Props with a configuration', () => {
     expect(extractProps('Element', obj1, config2)).toEqual('[a=foo];[c=true];');
   });
 
+  test('can handle if a prop has a circular ref', () => {
+    const myProp: { foo?: any } = {};
+    myProp.foo = myProp;
+    const obj2 = _.merge({}, obj1, { stateNode: { props: { c: myProp } } });
+    expect(extractProps('Element', obj2, config)).toEqual(
+      '[a=foo];[c.foo.foo.foo=object Object];'
+    );
+  });
+
   test("functions don't come through", () => {
     const obj2 = _.merge({}, obj1, {
       stateNode: {

--- a/js/util/extractProps.ts
+++ b/js/util/extractProps.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { getCombinedInclusionList } from './combineConfigs';
 import {
   containsReservedCharacter,
@@ -91,7 +92,16 @@ export const extractProps = (
     props = fiberNode.memoizedProps;
   }
 
-  const filteredProps = _.pick(props, inclusionList);
+  const filteredProps = _(props)
+    .pick(inclusionList)
+    .mapValues((prop: any) => {
+      if (React.isValidElement(prop)) {
+        // :TODO: (jmtaber129): Consider pulling information from the React element.
+        return 'React.element';
+      }
+      return prop;
+    })
+    .value();
 
   // KLUDGE: We want to capture the `key` property for list components that have it set,
   // but we can't simply add to the list of props captured for all components in
@@ -100,7 +110,7 @@ export const extractProps = (
   // prop for its own use; it is intended to be reserved for internal use. (HEAP-8473)
   const flattenedProps = Object.assign(
     { key: fiberNode.key },
-    flatten(filteredProps)
+    flatten(filteredProps, { maxDepth: 4 })
   );
 
   let propsString = '';


### PR DESCRIPTION
## Description
Currently, if the value of a prop to be captured is an object with a circular reference, or a React element (which is a special case of objects with circular refs), our library will blow the call stack. Example of React element prop:
```
<ListItem rightTitle={<Text>Foo</Text>} />
```

Correct this two ways:
* Set a `maxDepth` before attempting to flatten a prop value to avoid circular refs.
* Set the prop value to be `React.element` when the prop is a valid React element.

In the future, we can set the prop value of React elements to be more representative of the actual element, but that's outside the scope of this PR.

## Test Plan
Added unit tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
