### PR TITLE
Bump to version 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+### Security
+__END_UNRELEASED__
+
+## [0.9.1] - 2019-12-20
+
+### Fixed
 - Fixed bug where app would crash when `Heap.track()` is called if React Navigation autocapture isn't set up. [#165](https://github.com/heap/react-native-heap/issues/165).
 - Strip additional special characters from props and component names to prevent hierarchy matching/parsing breakages.
 - Upgraded Heap iOS SDK dependency to 6.5.3 to pick up bug fixes since version 6.5.0.
 - Don't crash when capturing props with circular references or React JSX elements.
-
-### Security
-__END_UNRELEASED__
 
 ## [0.9.0] - 2019-12-05
 

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - glog (0.3.5)
   - React (0.57.5):
     - React/Core (= 0.57.5)
-  - react-native-heap (0.9.0):
+  - react-native-heap (0.9.1):
     - React
   - React/Core (0.57.5):
     - yoga (= 0.57.5.React)

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "./preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.9.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.9.1.tgz",
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
## Description
Bump the version of RNHeap to 0.9.1.

Merging this is blocked on https://github.com/heap/react-native-heap/pull/170 and running detox tests again.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
