### PR TITLE
Telemetry metadata enrichment

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -5,9 +5,13 @@ assert = require('should/as-function');
 nodeUtil = require('util');
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
+packageJson = require('../package.json');
 
 const BASICS_PAGE_TOP_HIERARCHY =
   '@AppContainer;|@App;|@Provider;|@withReactNavigationAutotrack(NavigationContainer);|@NavigationContainer;|@Navigator;|@NavigationView;|@TabNavigationView;|@ScreenContainer;|@ResourceSavingScene;[key=Basics];|@SceneView;|@Connect(BasicsPage);|@BasicsPage;|@ScrollView;[testID=scrollContainer];|';
+
+const SDK_VERSION = packageJson.version;
+assert.exist(SDK_VERSION);
 
 const doTestActions = async () => {
   // Open the Basics tab in the tab navigator.
@@ -82,7 +86,16 @@ describe('Basic React Native and Interaction Support', () => {
         {
           a: '2084764307',
           t: 'pressInTestEvent1',
-          sprops: ['screen_path', 'Basics', 'screen_name', 'Basics'],
+          sprops: [
+            'screen_path',
+            'Basics',
+            'screen_name',
+            'Basics',
+            'is_using_react_navigation_hoc',
+            '1',
+            'source_version',
+            SDK_VERSION,
+          ],
         },
         event => {
           return !(
@@ -98,7 +111,16 @@ describe('Basic React Native and Interaction Support', () => {
         {
           a: '2084764307',
           t: 'pressInTestEvent2',
-          sprops: ['screen_path', 'Basics', 'screen_name', 'Basics'],
+          sprops: [
+            'screen_path',
+            'Basics',
+            'screen_name',
+            'Basics',
+            'is_using_react_navigation_hoc',
+            '1',
+            'source_version',
+            SDK_VERSION,
+          ],
         },
         event => {
           return (
@@ -114,7 +136,16 @@ describe('Basic React Native and Interaction Support', () => {
         {
           a: '2084764307',
           t: 'pressInTestEvent3',
-          sprops: ['screen_path', 'Basics', 'screen_name', 'Basics'],
+          sprops: [
+            'screen_path',
+            'Basics',
+            'screen_name',
+            'Basics',
+            'is_using_react_navigation_hoc',
+            '1',
+            'source_version',
+            SDK_VERSION,
+          ],
         },
         event => {
           return (
@@ -130,7 +161,16 @@ describe('Basic React Native and Interaction Support', () => {
         {
           a: '2084764307',
           t: 'pressInTestEvent4',
-          sprops: ['screen_path', 'Basics', 'screen_name', 'Basics'],
+          sprops: [
+            'screen_path',
+            'Basics',
+            'screen_name',
+            'Basics',
+            'is_using_react_navigation_hoc',
+            '1',
+            'source_version',
+            SDK_VERSION,
+          ],
         },
         event => {
           return !(
@@ -211,6 +251,12 @@ describe('Basic React Native and Interaction Support', () => {
                 screen_name: {
                   string: 'Basics',
                 },
+                source_version: {
+                  string: SDK_VERSION,
+                },
+                is_using_react_navigation_hoc: {
+                  string: 'true',
+                },
               },
             },
           },
@@ -243,6 +289,12 @@ describe('Basic React Native and Interaction Support', () => {
                 screen_name: {
                   string: 'Basics',
                 },
+                source_version: {
+                  string: SDK_VERSION,
+                },
+                is_using_react_navigation_hoc: {
+                  string: 'true',
+                },
               },
             },
           },
@@ -259,6 +311,12 @@ describe('Basic React Native and Interaction Support', () => {
                 },
                 screen_name: {
                   string: 'Basics',
+                },
+                source_version: {
+                  string: SDK_VERSION,
+                },
+                is_using_react_navigation_hoc: {
+                  string: 'true',
                 },
               },
             },
@@ -283,6 +341,12 @@ describe('Basic React Native and Interaction Support', () => {
                 },
                 screen_name: {
                   string: 'Basics',
+                },
+                source_version: {
+                  string: SDK_VERSION,
+                },
+                is_using_react_navigation_hoc: {
+                  string: 'true',
                 },
               },
             },
@@ -312,6 +376,12 @@ describe('Basic React Native and Interaction Support', () => {
                 screen_name: {
                   string: 'Basics',
                 },
+                source_version: {
+                  string: SDK_VERSION,
+                },
+                is_using_react_navigation_hoc: {
+                  string: 'true',
+                },
               },
             },
           },
@@ -339,6 +409,12 @@ describe('Basic React Native and Interaction Support', () => {
                 },
                 screen_name: {
                   string: 'Basics',
+                },
+                source_version: {
+                  string: SDK_VERSION,
+                },
+                is_using_react_navigation_hoc: {
+                  string: 'true',
                 },
               },
             },
@@ -428,6 +504,8 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
 
@@ -441,6 +519,8 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
 
@@ -496,6 +576,8 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_INACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
 
@@ -509,6 +591,8 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
 
@@ -522,6 +606,8 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_INACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
 
@@ -531,6 +617,8 @@ describe('Basic React Native and Interaction Support', () => {
         rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
 
@@ -540,6 +628,8 @@ describe('Basic React Native and Interaction Support', () => {
         rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
 
@@ -550,6 +640,8 @@ describe('Basic React Native and Interaction Support', () => {
         page_index: '1',
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
 
@@ -560,6 +652,8 @@ describe('Basic React Native and Interaction Support', () => {
         placeholder_text: 'foo placeholder',
         screen_name: 'Basics',
         screen_path: 'Basics',
+        source_version: SDK_VERSION,
+        is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
   });

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -14,7 +14,7 @@ import { autocaptureTextInputChange } from './autotrack/textInput';
 import { checkDisplayNamePlugin } from './util/checkDisplayNames';
 import { withReactNavigationAutotrack } from './autotrack/reactNavigation';
 import { bailOnError } from './util/bailer';
-import NavigationUtil from './util/navigationUtil';
+import { getContextualProps } from './util/contextualProps';
 
 const flatten = require('flat');
 const RNHeap = NativeModules.RNHeap;
@@ -35,8 +35,7 @@ const manualTrack = bailOnError((event, payload) => {
     // simulate a failure.
     const flatten = require('flat');
 
-    const contextualProps =
-      NavigationUtil.getScreenPropsForCurrentRoute() || {};
+    const contextualProps = getContextualProps();
 
     payload = payload || {};
     RNHeap.manuallyTrackEvent(event, flatten(payload), contextualProps);

--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -4,6 +4,11 @@ import { NativeModules } from 'react-native';
 import NavigationUtil from '../util/navigationUtil';
 import Heap from '../Heap';
 
+const packageJson = require('../../package.json');
+
+const SDK_VERSION = packageJson.version;
+expect(SDK_VERSION).toBeDefined();
+
 jest.mock('../util/navigationUtil');
 
 describe('The Heap object', () => {
@@ -53,8 +58,10 @@ describe('The Heap object', () => {
 
     NavigationUtil.getScreenPropsForCurrentRoute.mockImplementation(() => {
       return {
+        is_using_react_navigation_hoc: false,
         screen_path: 'Basics::Foo',
         screen_name: 'Foo',
+        source_version: SDK_VERSION,
       };
     });
   });
@@ -65,8 +72,10 @@ describe('The Heap object', () => {
       expect(mockTrack.mock.calls[0][0]).toBe('foo');
       expect(mockTrack.mock.calls[0][1]).toEqual(expectedProps);
       expect(mockTrack.mock.calls[0][2]).toEqual({
+        is_using_react_navigation_hoc: false,
         screen_path: 'Basics::Foo',
         screen_name: 'Foo',
+        source_version: SDK_VERSION,
       });
     };
 

--- a/js/autotrack/__tests__/common.spec.js
+++ b/js/autotrack/__tests__/common.spec.js
@@ -13,6 +13,11 @@ import {
   withHeapIgnore,
 } from '../heapIgnore';
 
+const packageJson = require('../../../package.json');
+
+const SDK_VERSION = packageJson.version;
+expect(SDK_VERSION).toBeDefined();
+
 jest.unmock('react-native');
 
 // Placeholder functional component for hierarchy tests.
@@ -50,9 +55,11 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@Text;[testID=targetElement];|',
+        source_version: SDK_VERSION,
       });
     });
 
@@ -73,9 +80,11 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@MySpecialComponent;|@Text;[testID=targetElement];|',
+        source_version: SDK_VERSION,
       });
     });
 
@@ -93,9 +102,11 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@ListItem;[rightTitle=React.element];|@Text;[testID=targetElement];|',
+        source_version: SDK_VERSION,
       });
     });
   });
@@ -129,9 +140,11 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|',
+        source_version: SDK_VERSION,
       });
     });
 
@@ -152,9 +165,11 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;|',
+        source_version: SDK_VERSION,
       });
     });
 
@@ -175,8 +190,10 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;[testID=targetElement];|',
+        source_version: SDK_VERSION,
       });
     });
 
@@ -200,9 +217,11 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;[testID=targetElement];|',
+        source_version: SDK_VERSION,
       });
     });
 
@@ -232,8 +251,10 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@BarFunction;|@HeapIgnore;|',
+        source_version: SDK_VERSION,
       });
     });
 
@@ -252,8 +273,10 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@withHeapIgnore(Text);[testID=targetElement];|@HeapIgnore;|@Text;|',
+        source_version: SDK_VERSION,
       });
     });
 
@@ -270,8 +293,10 @@ describe('Common autotrack utils', () => {
         .filter(Text);
       const normalProps = getBaseComponentProps(normalComponent.instance());
       expect(normalProps).toEqual({
+        is_using_react_navigation_hoc: false,
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnoreTargetText;|@HeapIgnore;|@Text;[testID=targetElement];|',
+        source_version: SDK_VERSION,
       });
     });
 

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -5,7 +5,7 @@ import { Fiber as FiberNode } from 'react-reconciler';
 import { extractProps } from '../util/extractProps';
 import { BASE_HEAP_IGNORE_PROPS, getNextHeapIgnoreProps } from './heapIgnore';
 import { builtinPropExtractorConfig } from '../propExtractorConfig';
-import NavigationUtil from '../util/navigationUtil';
+import { getContextualProps } from '../util/contextualProps';
 import { stripReservedCharacters } from '../util/reservedCharacters';
 
 // The type definition of 'Component' from '@types/react' doesn't include the internal
@@ -71,7 +71,7 @@ export const getBaseComponentProps: (
     targetText = '';
   }
 
-  const screenProps = NavigationUtil.getScreenPropsForCurrentRoute();
+  const screenProps = getContextualProps();
 
   const autotrackProps: AutotrackProps = {
     rn_hierarchy: hierarchy,

--- a/js/util/contextualProps.ts
+++ b/js/util/contextualProps.ts
@@ -1,0 +1,11 @@
+import NavigationUtil from './navigationUtil';
+import { getMetadataProps } from './metadataPropUtil';
+import * as _ from 'lodash';
+
+export const getContextualProps = () => {
+  return _.merge(
+    {},
+    getMetadataProps(),
+    NavigationUtil.getScreenPropsForCurrentRoute()
+  );
+};

--- a/js/util/metadataPropUtil.ts
+++ b/js/util/metadataPropUtil.ts
@@ -5,6 +5,6 @@ const { version } = require('../../package.json');
 export const getMetadataProps = () => {
   return {
     source_version: version,
-    is_using_react_navigation_hoc: NavigationUtil.isEnabled(),
+    is_using_react_navigation_hoc: NavigationUtil.isHocEnabled(),
   };
 };

--- a/js/util/metadataPropUtil.ts
+++ b/js/util/metadataPropUtil.ts
@@ -1,0 +1,10 @@
+import NavigationUtil from './navigationUtil';
+
+const { version } = require('../../package.json');
+
+export const getMetadataProps = () => {
+  return {
+    source_version: version,
+    is_using_react_navigation_hoc: NavigationUtil.isEnabled(),
+  };
+};

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -25,7 +25,7 @@ export default class NavigationUtil {
     return null;
   }
 
-  static isEnabled(): boolean {
+  static isHocEnabled(): boolean {
     return !!this.heapNavRef;
   }
 

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -25,6 +25,10 @@ export default class NavigationUtil {
     return null;
   }
 
+  static isEnabled(): boolean {
+    return !!this.heapNavRef;
+  }
+
   // :TODO: (jmtaber129): Add type for navigationState.
   static getActiveRouteProps(
     navigationState: any


### PR DESCRIPTION
## Description
Enrich events with telemetry metadata.  Specifically, the RNHeap SDK version and whether the React Navigation HOC has been instantiated.

## Test Plan
Update e2e tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [] ~If this is a bugfix/feature, the changelog has been updated~ (N/A)
