### PR TITLE
[HEAP-9394] Add getUserId method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+- Added `getUserId()` method for fetching the current Heap User ID from the underlying native SDK.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -5,6 +5,7 @@ reactNative.NativeModules = {
     manuallyTrackEvent: jest.fn(),
     autocaptureEvent: jest.fn(),
     setAppId: jest.fn(),
+    getUserId: jest.fn(),
     identify: jest.fn(),
     resetIdentity: jest.fn(),
     addUserProperties: jest.fn(),

--- a/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
+++ b/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
@@ -1,5 +1,6 @@
 package com.heapanalytics.reactnative;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -38,6 +39,11 @@ public class RNHeapLibraryModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void identify(String identity) {
     Heap.identify(identity);
+  }
+
+  @ReactMethod
+  public void getUserId(Promise promise) {
+    promise.resolve(Heap.getUserId());
   }
 
   @ReactMethod

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -220,6 +220,7 @@ describe('Basic React Native and Interaction Support', () => {
       assert.not.exist(err);
       assert(res.length).not.equal(0);
 
+      // Make the page display the current userId, and assert on the displayed userId.
       await element(by.id('getUserId')).tap();
       await expect(element(by.id('userIdValue'))).toHaveText(res[0]['u']);
     });
@@ -489,6 +490,7 @@ describe('Basic React Native and Interaction Support', () => {
       assert.not.exist(err);
       assert(res.length).not.equal(0);
 
+      // Make the page display the current userId, and assert on the displayed userId.
       await element(by.id('getUserId')).tap();
       await expect(element(by.id('userIdValue'))).toHaveText(
         res[0]['user']['id']['value']

--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -206,6 +206,24 @@ describe('Basic React Native and Interaction Support', () => {
       assert(res[0]['i']).equal('foobar');
     });
 
+    it('should get user id', async () => {
+      const { err, res } = await new Promise(resolve => {
+        // Fetch a post-resetIdentity event.
+        testUtil.findEventInRedisRequests(
+          { t: 'BASICS_SENTINEL' },
+          (err, res) => {
+            resolve({ err, res });
+          }
+        );
+      });
+
+      assert.not.exist(err);
+      assert(res.length).not.equal(0);
+
+      await element(by.id('getUserId')).tap();
+      await expect(element(by.id('userIdValue'))).toHaveText(res[0]['u']);
+    });
+
     it('should reset identity', async () => {
       const { err1, err2, res1, res2 } = await new Promise(resolve => {
         // Fetch a pre-resetIdentity event.
@@ -455,6 +473,26 @@ describe('Basic React Native and Interaction Support', () => {
       assert.not.exist(err);
       assert(res.length).equal(1);
       assert(res[0]['toIdentity']).equal('foobar');
+    });
+
+    it('should get user id', async () => {
+      const { err, res } = await new Promise(resolve => {
+        // Fetch a post-resetIdentity event.
+        testUtil.findAndroidEventInRedisRequests(
+          { event: { sourceCustomEvent: { name: 'BASICS_SENTINEL' } } },
+          (err, res) => {
+            resolve({ err, res });
+          }
+        );
+      });
+
+      assert.not.exist(err);
+      assert(res.length).not.equal(0);
+
+      await element(by.id('getUserId')).tap();
+      await expect(element(by.id('userIdValue'))).toHaveText(
+        res[0]['user']['id']['value']
+      );
     });
 
     it('should reset identity', async () => {

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -48,6 +48,17 @@ class MyTextInput extends Component {
 }
 
 class BasicsPage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { userId: '' };
+  }
+
+  _onGetUserId() {
+    Heap.getUserId().then(userId => {
+      this.setState({ userId });
+    });
+  }
+
   render() {
     return (
       <ScrollView
@@ -109,6 +120,14 @@ class BasicsPage extends Component {
           title="Clear Event Properties"
           onPress={() => Heap.clearEventProperties()}
         />
+        <Button
+          testID="getUserId"
+          title="Log user ID"
+          onPress={() => this._onGetUserId()}
+        />
+        <Text testID="userIdValue">
+          {this.state.userId}
+        </Text>
         <TouchableOpacity testID="touchableOpacityText">
           <Text>Touchable Opacity</Text>
           <Text>Foo</Text>

--- a/examples/TestDriver/src/pages/basics.js
+++ b/examples/TestDriver/src/pages/basics.js
@@ -125,9 +125,7 @@ class BasicsPage extends Component {
           title="Log user ID"
           onPress={() => this._onGetUserId()}
         />
-        <Text testID="userIdValue">
-          {this.state.userId}
-        </Text>
+        <Text testID="userIdValue">{this.state.userId}</Text>
         <TouchableOpacity testID="touchableOpacityText">
           <Text>Touchable Opacity</Text>
           <Text>Foo</Text>

--- a/ios/RNHeap.m
+++ b/ios/RNHeap.m
@@ -61,6 +61,11 @@ RCT_EXPORT_METHOD(manuallyTrackEvent:(NSString *)event withProperties:(NSDiction
     #pragma clang diagnostic pop
 }
 
+RCT_REMAP_METHOD(getUserId, getUserIdWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  NSString *userId = [Heap userId];
+  resolve(userId);
+}
+
 RCT_EXPORT_METHOD(identify:(NSString *)identity) {
   [Heap identify:identity];
 }

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -51,6 +51,7 @@ export default {
   setAppId: bailOnError(appId => RNHeap.setAppId(appId)),
 
   // User Properties
+  getUserId: bailOnError(() => RNHeap.getUserId()),
   identify: bailOnError(identity => RNHeap.identify(identity)),
   resetIdentity: bailOnError(() => RNHeap.resetIdentity()),
   addUserProperties: bailOnError(properties => {

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -51,6 +51,7 @@ export default {
   setAppId: bailOnError(appId => RNHeap.setAppId(appId)),
 
   // User Properties
+  // Returns a promise that resolves to the Heap user ID.
   getUserId: bailOnError(() => RNHeap.getUserId()),
   identify: bailOnError(identity => RNHeap.identify(identity)),
   resetIdentity: bailOnError(() => RNHeap.resetIdentity()),

--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -14,6 +14,7 @@ jest.mock('../util/navigationUtil');
 describe('The Heap object', () => {
   let mockTrack,
     mockSetAppId,
+    mockGetUserId,
     mockIdentify,
     mockResetIdentity,
     mockAddUserProperties,
@@ -37,6 +38,9 @@ describe('The Heap object', () => {
 
     NativeModules.RNHeap.setAppId.mockReset();
     mockSetAppId = NativeModules.RNHeap.setAppId;
+
+    NativeModules.RNHeap.getUserId.mockReset();
+    mockGetUserId = NativeModules.RNHeap.getUserId;
 
     NativeModules.RNHeap.identify.mockReset();
     mockIdentify = NativeModules.RNHeap.identify;
@@ -132,6 +136,12 @@ describe('The Heap object', () => {
       expect(mockSetAppId.mock.calls[0][0]).toBe('foo');
     });
 
+    it('getUserId - handles the common case', async () => {
+      mockGetUserId.mockReturnValue(Promise.resolve('1234'));
+      const userId = await Heap.getUserId();
+      expect(userId).toBe('1234');
+    });
+
     it('identify - handles the common case', () => {
       Heap.identify('foo');
       expect(mockIdentify.mock.calls.length).toBe(1);
@@ -173,6 +183,11 @@ describe('The Heap object', () => {
     it('setAppId - prevents errors from bubbling up', () => {
       mockSetAppId.mockImplementation(throwFn);
       expect(() => Heap.setAppId('foo')).not.toThrow();
+    });
+
+    it('getUserId - prevents errors from bubbling up', () => {
+      mockGetUserId.mockImplementation(throwFn);
+      expect(() => Heap.getUserId()).not.toThrow();
     });
 
     it('identify - prevents errors from bubbling up', () => {


### PR DESCRIPTION
## Description
Adds a `getUserId()` method to the Heap API that returns a promise that resolves to the current userID (managed by the underlying native Heap SDK).

Because calls over the react native bridge to the native modules happen asynchronously, this method returns a promise.  For example, to get the user ID, you might do,
```
Heap.getUserId()
  .then(userId => {
    console.log(`User ID is ${userId}`);
  });
```
or, if you're using `async/await`, you might do
```
const userId = await Heap.getUserId();
console.log(`User ID is ${userId}`);
```
It is _not_ possible to do something like
```
console.log(`User ID is ${Heap.getUserId()}`)
```
because `Heap.getUserId()` will return a yet-to-be-resolved promise.

## Test Plan
* Add e2e Detox tests
* Add unit tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
