### PR TITLE
[HEAP-13861] Update index.d.ts typings with resetIdentity and getUserId methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+- Updated `index.d.ts` typings to include `resetIdentity()` and `getUserId()` methods.
+
 ### Security
 __END_UNRELEASED__
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -104,13 +104,22 @@ export function removeEventProperty(property: string): void;
 export function clearEventProperties(): void;
 
 /**
+ * Resets a user's identity to a random anonymous user ID. A new session for an anonymous user will begin when called if the user was
+ * previously identified. The method has no effect if the user was previously anonymous when called.
+ */
+export function resetIdentity(): void;
+
+/**
+ * Returns  a promise that resolves to the stringified version of the numeric user ID associated with user.
+ */
+export function getUserId(): Promise<string>;
+
+/**
  * The following functions are not available via the iOS and Android API.
  *
  * export function enableVisualizer(): void;
  * export function startDebug(): void;
  * export function stopDebug(): void;
- * export function resetIdentify(): void;
- * export function userId(): Promise<string>;
  * export function libVersion(): Promise<string>;
  * export function changeInterval(interval: number): void;
  */


### PR DESCRIPTION
## Description
Adds TS typings for `resetIdentity()` and `getUserId()` methods.

## Test Plan
Ran `tsc index.d.ts` to check compilation.

## Checklist
- ~[ ] Detox tests pass (only Heap employees are able run these)~ N/A.
- [x] If this is a bugfix/feature, the changelog has been updated
