### PR TITLE
[HEAP-13941] Add SDK version info to screenviews

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -5,13 +5,9 @@ assert = require('should/as-function');
 nodeUtil = require('util');
 testUtil = require('../../heap/test/util');
 rnTestUtil = require('./rnTestUtilities');
-packageJson = require('../package.json');
 
 const BASICS_PAGE_TOP_HIERARCHY =
   '@AppContainer;|@App;|@Provider;|@withReactNavigationAutotrack(NavigationContainer);|@NavigationContainer;|@Navigator;|@NavigationView;|@TabNavigationView;|@ScreenContainer;|@ResourceSavingScene;[key=Basics];|@SceneView;|@Connect(BasicsPage);|@BasicsPage;|@ScrollView;[testID=scrollContainer];|';
-
-const SDK_VERSION = packageJson.version;
-assert.exist(SDK_VERSION);
 
 const doTestActions = async () => {
   // Open the Basics tab in the tab navigator.
@@ -94,7 +90,7 @@ describe('Basic React Native and Interaction Support', () => {
             'is_using_react_navigation_hoc',
             '1',
             'source_version',
-            SDK_VERSION,
+            rnTestUtil.SDK_VERSION,
           ],
         },
         event => {
@@ -119,7 +115,7 @@ describe('Basic React Native and Interaction Support', () => {
             'is_using_react_navigation_hoc',
             '1',
             'source_version',
-            SDK_VERSION,
+            rnTestUtil.SDK_VERSION,
           ],
         },
         event => {
@@ -144,7 +140,7 @@ describe('Basic React Native and Interaction Support', () => {
             'is_using_react_navigation_hoc',
             '1',
             'source_version',
-            SDK_VERSION,
+            rnTestUtil.SDK_VERSION,
           ],
         },
         event => {
@@ -169,7 +165,7 @@ describe('Basic React Native and Interaction Support', () => {
             'is_using_react_navigation_hoc',
             '1',
             'source_version',
-            SDK_VERSION,
+            rnTestUtil.SDK_VERSION,
           ],
         },
         event => {
@@ -271,7 +267,7 @@ describe('Basic React Native and Interaction Support', () => {
                   string: 'Basics',
                 },
                 source_version: {
-                  string: SDK_VERSION,
+                  string: rnTestUtil.SDK_VERSION,
                 },
                 is_using_react_navigation_hoc: {
                   string: 'true',
@@ -309,7 +305,7 @@ describe('Basic React Native and Interaction Support', () => {
                   string: 'Basics',
                 },
                 source_version: {
-                  string: SDK_VERSION,
+                  string: rnTestUtil.SDK_VERSION,
                 },
                 is_using_react_navigation_hoc: {
                   string: 'true',
@@ -332,7 +328,7 @@ describe('Basic React Native and Interaction Support', () => {
                   string: 'Basics',
                 },
                 source_version: {
-                  string: SDK_VERSION,
+                  string: rnTestUtil.SDK_VERSION,
                 },
                 is_using_react_navigation_hoc: {
                   string: 'true',
@@ -362,7 +358,7 @@ describe('Basic React Native and Interaction Support', () => {
                   string: 'Basics',
                 },
                 source_version: {
-                  string: SDK_VERSION,
+                  string: rnTestUtil.SDK_VERSION,
                 },
                 is_using_react_navigation_hoc: {
                   string: 'true',
@@ -396,7 +392,7 @@ describe('Basic React Native and Interaction Support', () => {
                   string: 'Basics',
                 },
                 source_version: {
-                  string: SDK_VERSION,
+                  string: rnTestUtil.SDK_VERSION,
                 },
                 is_using_react_navigation_hoc: {
                   string: 'true',
@@ -430,7 +426,7 @@ describe('Basic React Native and Interaction Support', () => {
                   string: 'Basics',
                 },
                 source_version: {
-                  string: SDK_VERSION,
+                  string: rnTestUtil.SDK_VERSION,
                 },
                 is_using_react_navigation_hoc: {
                   string: 'true',
@@ -544,7 +540,7 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
@@ -559,7 +555,7 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
@@ -616,7 +612,7 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_INACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
@@ -631,7 +627,7 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_ACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
@@ -646,7 +642,7 @@ describe('Basic React Native and Interaction Support', () => {
         touch_state: 'RESPONDER_INACTIVE_PRESS_IN',
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
@@ -657,7 +653,7 @@ describe('Basic React Native and Interaction Support', () => {
         rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
@@ -668,7 +664,7 @@ describe('Basic React Native and Interaction Support', () => {
         rn_hierarchy: expectedHierarchy,
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
@@ -680,7 +676,7 @@ describe('Basic React Native and Interaction Support', () => {
         page_index: '1',
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });
@@ -692,7 +688,7 @@ describe('Basic React Native and Interaction Support', () => {
         placeholder_text: 'foo placeholder',
         screen_name: 'Basics',
         screen_path: 'Basics',
-        source_version: SDK_VERSION,
+        source_version: rnTestUtil.SDK_VERSION,
         is_using_react_navigation_hoc: rnTestUtil.getPlatformBoolean(true),
       });
     });

--- a/e2e/rnTestUtilities.js
+++ b/e2e/rnTestUtilities.js
@@ -1,10 +1,16 @@
 require('coffeescript').register();
 
 const _ = require('lodash');
+assert = require('should/as-function');
 const nodeUtil = require('util');
 
 db = require('../../heap/back/db');
 testUtil = require('../../heap/test/util');
+
+packageJson = require('../package.json');
+
+const SDK_VERSION = packageJson.version;
+assert.exist(SDK_VERSION);
 
 const HEAP_ENV_ID = '2084764307';
 
@@ -105,53 +111,14 @@ const assertAutotrackHierarchy = async (expectedName, expectedProps) => {
   }
 };
 
-const assertAndroidNavigationEvent = async (expectedPath, expectedType) => {
-  const commonProps = {
-    screen_path: {
-      string: expectedPath,
-    },
-  };
-  const props = expectedType
-    ? {
-        ...commonProps,
-        action: {
-          string: expectedType,
-        },
-      }
-    : commonProps;
-
-  return assertAndroidEvent({
-    envId: HEAP_ENV_ID,
-    event: {
-      sourceEvent: {
-        name: 'react_navigation_screenview',
-        sourceName: 'react_native',
-        sourceProperties: props,
-      },
-    },
-  });
-};
-
-const assertIosNavigationEvent = async (expectedPath, expectedType) => {
-  const commonProps = ['screen_path', expectedPath];
-  const props = expectedType
-    ? [...commonProps, 'action', expectedType]
-    : commonProps;
-  return assertIosPixel({
-    t: 'react_navigation_screenview',
-    source: 'react_native',
-    sprops: props,
-  });
-};
-
 const assertNavigationEvent = async (expectedPath, expectedType) => {
-  if (device.getPlatform() === 'android') {
-    return assertAndroidNavigationEvent(expectedPath, expectedType);
-  } else if (device.getPlatform() === 'ios') {
-    return assertIosNavigationEvent(expectedPath, expectedType);
-  } else {
-    throw new Error(`Unknown device type: ${device.getPlatform()}`);
-  }
+  const expectedProps = {
+    action: expectedType,
+    screen_path: expectedPath,
+    source_version: SDK_VERSION,
+  };
+
+  return assertAutotrackHierarchy('react_navigation_screenview', expectedProps);
 };
 
 pollForSentinel = async (sentinelValue, timeout = 60000) => {
@@ -226,4 +193,5 @@ module.exports = {
   waitIfIos,
   getPlatformBoolean,
   flushAllRedis,
+  SDK_VERSION,
 };

--- a/js/autotrack/reactNavigation.js
+++ b/js/autotrack/reactNavigation.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { bail, bailOnError } from '../util/bailer';
 import { getComponentDisplayName } from '../util/hocUtil';
 import NavigationUtil from '../util/navigationUtil';
+import { getContextualProps } from '../util/contextualProps';
 
 const EVENT_TYPE = 'react_navigation_screenview';
 
@@ -20,6 +21,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
     );
     if (prevScreenRoute !== nextScreenRoute) {
       track(EVENT_TYPE, {
+        ...getContextualProps(),
         screen_path: nextScreenRoute,
         action: action.type,
       });
@@ -43,6 +45,7 @@ export const withReactNavigationAutotrack = track => AppContainer => {
       } = NavigationUtil.getActiveRouteProps(this.topLevelNavigator.state.nav);
 
       track(EVENT_TYPE, {
+        ...getContextualProps(),
         screen_path: initialPageviewPath,
         action: INITIAL_ROUTE_TYPE,
       });


### PR DESCRIPTION
## Description
Add contextual props to screenview events.  This mostly just ensures that the RNHeap version is included on screenview events.

## Test Plan
E2E detox tests.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- ~[ ] If this is a bugfix/feature, the changelog has been updated~ Not a feature.
