### PR TITLE
[HEAP-14317] Bump Android dep to 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
 ### Changed
+- Upgraded the native Android Heap SDK to v1.6.0.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,6 +80,6 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    api 'com.heapanalytics.android:heap-android-client:1.3.0'
+    api 'com.heapanalytics.android:heap-android-client:1.6.0'
 }
 

--- a/examples/TestDriver/android/build.gradle
+++ b/examples/TestDriver/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 27
         targetSdkVersion = 26
         supportLibVersion = "27.1.1"
-        ext.heapVersion = '1.3.0'
+        ext.heapVersion = '1.6.0'
         ext.kotlinVersion = '1.3.0'
     }
     repositories {


### PR DESCRIPTION
## Description
Bump Android dependency from v1.3.0 to v1.6.0.

## Test Plan
Existing tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
