### PR TITLE
fix: add SystemConfiguration framework to .podspec

### DIFF
--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -17,6 +17,8 @@ Pod::Spec.new do |s|
   s.vendored_libraries = "ios/Vendor/libHeap.a"
 
   s.dependency "React"
+  
+  s.frameworks = "SystemConfiguration"
 
   s.script_phase = {
     name: 'Generate `HeapSettings.plist`',


### PR DESCRIPTION
## Description
Fixes the following build error (React 0.62.2)

```
Undefined symbols for architecture x86_64:
  "_SCNetworkReachabilityGetFlags", referenced from:
      -[HeapReachability connectionRequired] in libHeap.a(HeapReachability.o)
      -[HeapReachability currentReachabilityStatus] in libHeap.a(HeapReachability.o)
  "_SCNetworkReachabilityCreateWithAddress", referenced from:
      +[HeapReachability reachabilityWithAddress:] in libHeap.a(HeapReachability.o)
  "_SCNetworkReachabilityCreateWithName", referenced from:
      +[HeapReachability reachabilityWithHostName:] in libHeap.a(HeapReachability.o)
  "_SCNetworkReachabilityScheduleWithRunLoop", referenced from:
      -[HeapReachability startNotifier] in libHeap.a(HeapReachability.o)
  "_SCNetworkReachabilityUnscheduleFromRunLoop", referenced from:
      -[HeapReachability stopNotifier] in libHeap.a(HeapReachability.o)
  "_SCNetworkReachabilitySetCallback", referenced from:
      -[HeapReachability startNotifier] in libHeap.a(HeapReachability.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
