### PR TITLE
[HEAP-15381] Improve Support for HeapIgnore in minified apps [S]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+- Improve support for 'HeapIgnore' and its convenience components in minified apps.
+
 ### Security
 __END_UNRELEASED__
 

--- a/js/autotrack/heapIgnore.js
+++ b/js/autotrack/heapIgnore.js
@@ -3,11 +3,12 @@ import React from 'react';
 
 import { getComponentDisplayName } from '../util/hocUtil';
 
-export const HeapIgnore = props => {
-  // The only purpose of HeapIgnore is to tell the us which props apply to the subtree when we're
-  // traversing, so we just need to render it's children here.
-  return props.children;
-};
+export class HeapIgnore extends React.Component {
+  render() {
+    return this.props.children;
+  }
+}
+HeapIgnore.displayName = 'HeapIgnore';
 
 // Convenience component for only ignoring target text.
 export const HeapIgnoreTargetText = props => {
@@ -55,7 +56,7 @@ export const BASE_HEAP_IGNORE_PROPS = {
 };
 
 export const getNextHeapIgnoreProps = (currProps, element) => {
-  if (element.elementName !== 'HeapIgnore') {
+  if (element.elementName !== HeapIgnore.displayName) {
     return currProps;
   }
 


### PR DESCRIPTION
## Description
Improve support for HeapIgnore in minified apps by changing the `HeapIgnore` component to a class, explicitly set the component's `displayName`, and check against the class's displayName, rather than a string literal.

## Test Plan
Manually tested on a minified app.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
