### PR TITLE
[HEAP-16088] Upgrade native iOS Heap dependency to 6.8.1 [S]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
 ### Changed
+- Upgraded the native Heap iOS SDK dependency to 6.8.1.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/ios/Vendor/Heap.h
+++ b/ios/Vendor/Heap.h
@@ -1,6 +1,6 @@
 //
 //  Heap.h
-//  Version 6.7.0
+//  Version 6.8.1
 //  Copyright (c) 2014 Heap Inc. All rights reserved.
 //
 
@@ -28,6 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Don't capture the iOS advertiser ID (IDFA).
 @property (assign) BOOL disableAdvertiserIdCapture;
+
+/// Opt-out of telemetry capture.
+@property (assign) BOOL disableTelemetryCapture;
 
 @end
 


### PR DESCRIPTION
## Description
Upgrade the native Heap iOS dependency to 6.8.1.

## Test Plan
Existing e2e tests.

This was tested as a commit on top of https://github.com/heap/react-native-heap/pull/192, and was then cherry-picked onto a branch off of develop.  https://github.com/heap/react-native-heap/pull/192 needs additional work, so opening a PR for this off of develop even though tests don't run for me locally (Catalina, Xcode 11).

## Checklist
- [X] Detox tests pass (only Heap employees are able run these) - see above
- [X] If this is a bugfix/feature, the changelog has been updated
