### PR TITLE
[HEAP-15357] Update index.d.ts with HeapIgnore types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ __BEGIN_UNRELEASED__
 ### Removed
 ### Fixed
 - Improve support for 'HeapIgnore' and its convenience components in minified apps.
+- Updated `index.d.ts` typings to include `HeapIgnore` and related components.
 
 ### Security
 __END_UNRELEASED__

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,7 @@
+import * as React from 'react';
+
+import { HeapIgnore, HeapIgnoreTargetText } from './js/autotrack/heapIgnore';
+
 /**
  * `setAppId` Initializes Heap tracking and sets the app ID where you'll be sending data. It can be used to switch
  * between projects or between your production and development environments.
@@ -22,7 +26,7 @@ export function setAppId(appId: string): void;
  * @param withProperties a JSON object containing key-value pairs to be associated with an event.  Nested objects
  * will be flattened.
  */
-export function track(event: string, withProperties: object): void;
+export function track(event: string, properties?: object): void;
 
 /**
  * Attach a unique identity to a user.
@@ -110,9 +114,29 @@ export function clearEventProperties(): void;
 export function resetIdentity(): void;
 
 /**
- * Returns  a promise that resolves to the stringified version of the numeric user ID associated with user.
+ * Returns a promise that resolves to the stringified version of the numeric user ID associated with user.
  */
 export function getUserId(): Promise<string>;
+
+/**
+ * Returns an HOC of a component with specific HeapIgnore properties.
+ *
+ * @param IgnoredComponent the component to wrap with HeapIgnore.
+ * @param heapIgnoreConfig the HeapIgnore configuration
+ */
+export function withHeapIgnore(IgnoredComponent: React.Component, heapIgnoreConfig?: object): React.Component;
+
+/**
+ * Component for ignoring all or parts of interactions with children of this component.
+ */
+export class Ignore extends React.Component {}
+
+/**
+ * Convenience component for ignoring 'target_text' on interactions with children of this component.
+ */
+export const IgnoreTargetText: React.SFC;
+
+export { HeapIgnore, HeapIgnoreTargetText };
 
 /**
  * The following functions are not available via the iOS and Android API.


### PR DESCRIPTION
## Description
Add types for `HeapIgnore` to type declarations.

## Test Plan
Created a typescript file and confirmed `tsc` 

## Checklist
- [ ] ~Detox tests pass (only Heap employees are able run these)~ N/A - e2e tests don't depend on types.
- [X] If this is a bugfix/feature, the changelog has been updated
