### PR TITLE
Add local EV endpoint to TestDriver Android build config [XS]

### DIFF
--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -128,6 +128,7 @@ android {
             buildConfigField "String", "heap_endpoint_track", "\"http://10.0.2.2:3000/api/integrations/android/track\""
             buildConfigField "String", "heap_endpoint_identify", "\"http://10.0.2.2:3000/api/integrations/android/identify\""
             buildConfigField "String", "heap_endpoint_adduserproperties", "\"http://10.0.2.2:3000/api/integrations/android/add_user_properties\""
+            buildConfigField "String", "heap_endpoint_eventdef", "\"http://10.0.2.2:5000/api/ev/android/message\""
         }
     }
     // applicationVariants are e.g. debug, release


### PR DESCRIPTION
## Description
Add the local endpoint configuration for the Android event visualizer to the TestDriver build config.  This allows local Android EV dev work to be done for React Native events.

## Checklist
- [ ] ~Detox tests pass (only Heap employees are able run these)~ N/A
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ N/A
