### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,20 @@ __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
 ### Changed
-- Upgraded the native Heap iOS SDK dependency to 6.8.1.
-
 ### Deprecated
 ### Removed
 ### Fixed
-- Improve support for 'HeapIgnore' and its convenience components in minified apps.
-- Updated `index.d.ts` typings to include `HeapIgnore` and related components.
-
 ### Security
 __END_UNRELEASED__
+
+## [0.12.0] - 2020-06-22
+
+### Changed
+- Upgraded the native Heap iOS SDK dependency to 6.8.1. This fixes an issue in which Install/Upgrade events would not fire for some installations
+
+### Fixed
+- Improve support for 'HeapIgnore' and its convenience components in minified apps.
+- Updated `index.d.ts` typings to include `HeapIgnore` and related components.
 
 ## [0.11.0] - 2020-04-10
 

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - glog (0.3.5)
   - React (0.57.5):
     - React/Core (= 0.57.5)
-  - react-native-heap (0.11.0):
+  - react-native-heap (0.12.0):
     - React
   - React/Core (0.57.5):
     - yoga (= 0.57.5.React)
@@ -81,7 +81,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga/yoga.podspec`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - boost-for-react-native
 
 EXTERNAL SOURCES:
@@ -102,14 +102,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
-  glog: e8acf0ebbf99759d3ff18c86c292a5898282dcde
-  React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
-  react-native-heap: 67c26efdefcfb8b55adedcd49b67669be7e550bd
-  RNGestureHandler: 7ccf2f3f60458e084f9ada01fbaf610f6fef073c
-  yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  React: 01aa04500b2957c2767e1dff9fe12e09444a467c
+  react-native-heap: 75ef43fdf8cf10d3a347d00b3c66d1170b7e9ad2
+  RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
+  yoga: a5c0ba30ebe82c13612b4c9301ad29708b8978dc
 
 PODFILE CHECKSUM: 94963ca9da08a6f38a9019eb8da64ec0f890b712
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.8.4

--- a/examples/TestDriver/ios/TestDriver.xcodeproj/project.pbxproj
+++ b/examples/TestDriver/ios/TestDriver.xcodeproj/project.pbxproj
@@ -209,7 +209,6 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				347B4380528F227E831E33B1 /* [CP] Embed Pods Frameworks */,
-				07B147202AAE973B4EDD780A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -350,28 +349,6 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
-		07B147202AAE973B4EDD780A /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-resources.sh",
-				"${PODS_CONFIGURATION_BUILD_DIR}/react-native-heap/HeapSettings.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/HeapSettings.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		2853483F96FDDC922D462B77 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -413,31 +390,29 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/DoubleConversion/DoubleConversion.framework",
 				"${BUILT_PRODUCTS_DIR}/Folly/folly.framework",
 				"${BUILT_PRODUCTS_DIR}/RNGestureHandler/RNGestureHandler.framework",
 				"${BUILT_PRODUCTS_DIR}/React/React.framework",
 				"${BUILT_PRODUCTS_DIR}/glog/glog.framework",
+				"${BUILT_PRODUCTS_DIR}/react-native-heap/react_native_heap.framework",
 				"${BUILT_PRODUCTS_DIR}/yoga/yoga.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DoubleConversion.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/folly.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RNGestureHandler.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/react_native_heap.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/yoga.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestDriver/Pods-TestDriver-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E5F03DDBB7275D0F8105EA52 /* [CP] Check Pods Manifest.lock */ = {

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "./preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.11.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.12.0.tgz",
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
## Description
Bump version to 0.12.0 for release.

Detox passes for Android.  iOS tests pass by cherry-picking this commit onto https://github.com/heap/react-native-heap/pull/192 and running iOS detox tests.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
