### PR TITLE
[HEAP-16352] Alpha support for Touchables in React Native 0.62+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+- Added support for `Touchable` components in React Native v0.62+ via Pressability instrumentation.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -300,7 +300,10 @@ const pressabilityWrappingTemplate = template(`
   CONFIG_IDENTIFIER = Heap.wrapPressabilityConfig(CONFIG_IDENTIFIER) || CONFIG_IDENTIFIER;
 `);
 
-// Instruments 'Touchable's in RN 0.62+ by passing the 'Pressability' config to the Heap library to wrap the config.
+// Instruments 'Touchable's in RN 0.62+ by passing the 'Pressability' config to the Heap library to wrap the config.  See
+// https://github.com/facebook/react-native/blob/a5151c2b5f6f03896eb7d9df873c5f61a706f055/Libraries/Components/Touchable/TouchableOpacity.js#L139
+// and
+// https://github.com/facebook/react-native/blob/a5151c2b5f6f03896eb7d9df873c5f61a706f055/Libraries/Pressability/Pressability.js#L405-L407.
 const pressabilityInstrumentationVisitor = {
   ClassMethod(path) {
     const { node } = path;

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -314,7 +314,7 @@ const pressabilityInstrumentationVisitor = {
     });
 
     path.get('body').unshiftContainer('body', configWrapExpression);
-  }
+  },
 };
 
 function transform(babel) {
@@ -333,7 +333,7 @@ function transform(babel) {
         if (path.node.id.name === 'Pressability') {
           path.traverse(pressabilityInstrumentationVisitor);
         }
-      }
+      },
     },
   };
 }

--- a/instrumentor/test/fixtures/is-not-pressability/code.js
+++ b/instrumentor/test/fixtures/is-not-pressability/code.js
@@ -1,0 +1,7 @@
+export default class Touchability {
+  _config: PressabilityConfig;
+
+  constructor(config: PressabilityConfig) {
+    this._config = config;
+  }
+}

--- a/instrumentor/test/fixtures/is-not-pressability/output.js
+++ b/instrumentor/test/fixtures/is-not-pressability/output.js
@@ -1,0 +1,15 @@
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
+
+var Touchability = function Touchability(config) {
+  (0, _classCallCheck2.default)(this, Touchability);
+  this._config = config;
+};
+
+exports.default = Touchability;

--- a/instrumentor/test/fixtures/is-pressability/code.js
+++ b/instrumentor/test/fixtures/is-pressability/code.js
@@ -1,0 +1,7 @@
+export default class Pressability {
+  _config: PressabilityConfig;
+
+  constructor(config: PressabilityConfig) {
+    this._config = config;
+  }
+}

--- a/instrumentor/test/fixtures/is-pressability/output.js
+++ b/instrumentor/test/fixtures/is-pressability/output.js
@@ -1,0 +1,19 @@
+var _interopRequireDefault = require("@babel/runtime/helpers/interopRequireDefault");
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _classCallCheck2 = _interopRequireDefault(require("@babel/runtime/helpers/classCallCheck"));
+
+var Pressability = function Pressability(config) {
+  (0, _classCallCheck2.default)(this, Pressability);
+
+  var Heap = require('@heap/react-native-heap').default;
+
+  config = Heap.wrapPressabilityConfig(config) || config;
+  this._config = config;
+};
+
+exports.default = Pressability;

--- a/instrumentor/test/index.js
+++ b/instrumentor/test/index.js
@@ -78,7 +78,7 @@ describe('autotrack instrumentor plugin', () => {
     assert.equal(actual, expected);
   });
 
-  it('non-pressability should be instrumented', () => {
+  it('non-pressability should not be instrumented', () => {
     var actual = getActualTransformedFile('is-not-pressability');
     var expected = getExpectedTransformedFile('is-not-pressability');
     assert.equal(actual, expected);

--- a/instrumentor/test/index.js
+++ b/instrumentor/test/index.js
@@ -71,6 +71,18 @@ describe('autotrack instrumentor plugin', () => {
     var expected = getExpectedTransformedFile('not-text-input');
     assert.equal(actual, expected);
   });
+
+  it('pressability should be instrumented', () => {
+    var actual = getActualTransformedFile('is-pressability');
+    var expected = getExpectedTransformedFile('is-pressability');
+    assert.equal(actual, expected);
+  });
+
+  it('non-pressability should be instrumented', () => {
+    var actual = getActualTransformedFile('is-not-pressability');
+    var expected = getExpectedTransformedFile('is-not-pressability');
+    assert.equal(actual, expected);
+  });
 });
 
 const getActualTransformedFile = fixtureName => {

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -7,7 +7,7 @@ import {
   HeapIgnoreTargetText,
   withHeapIgnore,
 } from './autotrack/heapIgnore';
-import { autotrackPress } from './autotrack/touchables';
+import { autotrackPress, wrapPressabilityConfig } from './autotrack/touchables';
 import { autotrackSwitchChange } from './autotrack/switches';
 import { autotrackScrollView } from './autotrack/scrollViews';
 import { autocaptureTextInputChange } from './autotrack/textInput';
@@ -86,6 +86,7 @@ export default {
   autocaptureTextInput: bailOnError(
     autocaptureTextInputChange(autocaptureTrack)
   ),
+  wrapPressabilityConfig: bailOnError(wrapPressabilityConfig(autocaptureTrack)),
   withReactNavigationAutotrack: withReactNavigationAutotrack(autocaptureTrack),
   Ignore: HeapIgnore,
   IgnoreTargetText: HeapIgnoreTargetText,

--- a/js/autotrack/__tests__/common.spec.js
+++ b/js/autotrack/__tests__/common.spec.js
@@ -6,7 +6,7 @@ import { Text, View } from 'react-native';
 const foo = require('react-native');
 import { shallow, mount, render } from 'enzyme';
 
-import { getBaseComponentProps } from '../common';
+import { getBaseComponentPropsFromComponent } from '../common';
 import {
   HeapIgnore,
   HeapIgnoreTargetText,
@@ -53,7 +53,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         target_text: 'foobar',
@@ -78,7 +80,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         target_text: 'foobar',
@@ -100,7 +104,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         target_text: 'foobar',
@@ -123,7 +129,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toBe(null);
     });
 
@@ -138,7 +146,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         target_text: 'foobar',
@@ -163,7 +173,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         target_text: 'foobar',
@@ -188,7 +200,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         rn_hierarchy:
@@ -215,7 +229,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         target_text: 'foobar',
@@ -249,7 +265,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         rn_hierarchy:
@@ -271,7 +289,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         rn_hierarchy:
@@ -291,7 +311,9 @@ describe('Common autotrack utils', () => {
       const normalComponent = wrapper
         .find({ testID: 'targetElement' })
         .filter(Text);
-      const normalProps = getBaseComponentProps(normalComponent.instance());
+      const normalProps = getBaseComponentPropsFromComponent(
+        normalComponent.instance()
+      );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
         rn_hierarchy:

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -44,17 +44,21 @@ interface ComponentHierarchyTraversalElement {
   propsString: string;
 }
 
+export const getBaseComponentPropsFromComponent: (
+  component: Component
+) => AutotrackProps | null = componentThis => {
+  return getBaseComponentPropsFromFiber(componentThis._reactInternalFiber);
+};
+
 // Returns an 'AutotrackProps' containing a base set of component properties if we're not ignoring
 // the full interaction due to HeapIgnore.
 // Returns null if we're ignoring the full interaction due to HeapIgnore.
-export const getBaseComponentProps: (
-  component: Component
-) => AutotrackProps | null = componentThis => {
+export const getBaseComponentPropsFromFiber: (
+  fiberNode: FiberNode
+) => AutotrackProps | null = fiberNode => {
   // Get the hierarchy traversal from root to target component, then get the actual hierarchy from
   // the traversal representation.
-  const touchableHierarchyTraversal = getComponentHierarchyTraversal(
-    componentThis
-  );
+  const touchableHierarchyTraversal = getComponentHierarchyTraversal(fiberNode);
   const { hierarchy, heapIgnoreProps } = getHierarchyStringFromTraversal(
     touchableHierarchyTraversal
   );
@@ -66,7 +70,7 @@ export const getBaseComponentProps: (
   // Only look for target text if we're not HeapIgnore-ing target text.
   let targetText;
   if (heapIgnoreProps.allowTargetText) {
-    targetText = getTargetText(componentThis._reactInternalFiber);
+    targetText = getTargetText(fiberNode);
   } else {
     targetText = '';
   }
@@ -86,18 +90,16 @@ export const getBaseComponentProps: (
 };
 
 const getComponentHierarchyTraversal: (
-  comp: Component
-) => ComponentHierarchyTraversalElement[] = componentThis => {
+  fiberNode: FiberNode
+) => ComponentHierarchyTraversalElement[] = fiberNode => {
   // :TODO: (jmtaber129): Remove this if/when we support pre-fiber React.
-  if (!componentThis._reactInternalFiber) {
+  if (!fiberNode) {
     throw new Error(
       'Pre-fiber React versions (React 16) are currently not supported by Heap autotrack.'
     );
   }
 
-  return getFiberNodeComponentHierarchyTraversal(
-    componentThis._reactInternalFiber
-  );
+  return getFiberNodeComponentHierarchyTraversal(fiberNode);
 };
 
 // Traverse up the hierarchy from the current component up to the root, and return an array of

--- a/js/autotrack/scrollViews.js
+++ b/js/autotrack/scrollViews.js
@@ -1,4 +1,4 @@
-import { getBaseComponentProps } from './common';
+import { getBaseComponentPropsFromComponent } from './common';
 import * as _ from 'lodash';
 
 export const autotrackScrollView = track => (
@@ -16,7 +16,7 @@ export const autotrackScrollView = track => (
   // Target text on a scrollview will be the entire contents of the scrollview, which isn't
   // particularly meaningful. Just leave out the target text.
   const autotrackProps = _.omit(
-    getBaseComponentProps(componentThis),
+    getBaseComponentPropsFromComponent(componentThis),
     'target_text'
   );
 

--- a/js/autotrack/switches.js
+++ b/js/autotrack/switches.js
@@ -1,11 +1,11 @@
-import { getBaseComponentProps } from './common';
+import { getBaseComponentPropsFromComponent } from './common';
 
 export const autotrackSwitchChange = track => (
   eventType,
   componentThis,
   event
 ) => {
-  const autotrackProps = getBaseComponentProps(componentThis);
+  const autotrackProps = getBaseComponentPropsFromComponent(componentThis);
 
   if (!autotrackProps) {
     // We're not capturing this interaction.

--- a/js/autotrack/textInput.js
+++ b/js/autotrack/textInput.js
@@ -1,4 +1,4 @@
-import { getBaseComponentProps } from './common';
+import { getBaseComponentPropsFromComponent } from './common';
 import * as _ from 'lodash';
 
 const DEBOUNCE_PERIOD_MS = 1000;
@@ -24,7 +24,7 @@ const debouncedAutocaptureTextInputChange = track => (
   componentThis,
   event
 ) => {
-  const autotrackProps = getBaseComponentProps(componentThis);
+  const autotrackProps = getBaseComponentPropsFromComponent(componentThis);
 
   if (!autotrackProps) {
     // We're not capturing this interaction.

--- a/js/autotrack/touchables.js
+++ b/js/autotrack/touchables.js
@@ -44,6 +44,9 @@ const unsafePressHandler = (event, track, isLongPress) => {
 
 const pressHandler = bailOnError(unsafePressHandler);
 
+// Wrap the config passed to the 'Pressability' constructor by wrapping the 'onPress' and 'onLongPress' properties in the config, and
+// keeping all other properties as-is.  See the config passed to the 'Pressability' constructor in
+// https://github.com/facebook/react-native/blob/a5151c2b5f6f03896eb7d9df873c5f61a706f055/Libraries/Components/Touchable/TouchableOpacity.js#L143-L186.
 export const wrapPressabilityConfig = track => pressabilityConfig => {
   const newConfig = {
     ...pressabilityConfig,


### PR DESCRIPTION
Touchable support for React Native 0.62+.

This involves adding instrumentation to the new RN Pressability class's constructor, copying the config, and wrapping the config's onPress and onLongPress methods.

This PR is intended for an alpha release, so testing isn't as good as it should be.  These two commits were cherry-picked from https://github.com/heap/react-native-heap/pull/198 to keep develop clean.

Still need to run detox tests for <0.62 by cherry-picking these commits onto https://github.com/heap/react-native-heap/pull/192, but otherwise ready for review.

## Test Plan
Detox tests for android pass for the 0.62 app on https://github.com/heap/react-native-heap/pull/198, but a detox issue is preventing iOS tests from running.  Because this only changes instrumentation on the JS side, test results _shouldn't_ vary between android and iOS, but this should be tested on iOS before including this in a stable release.

## Checklist
- [ ] Detox tests pass (only Heap employees are able run these) (see above)
- [X] If this is a bugfix/feature, the changelog has been updated
