### PR TITLE
[HEAP-16697] Bump version to 0.13.0-alpha1

### DIFF
--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "./preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.12.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.13.0-alpha1.tgz",
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.12.0",
+  "version": "0.13.0-alpha1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.12.0",
+  "version": "0.13.0-alpha1",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
## Description
Bump version to 0.13.0-alpha1 for the RN 0.62 support changes.

Since this is only an alpha, and the TestDriver iOS test app isn't currently working on my machine (Catalina), I only ran Android detox tests.

## Checklist
- [ ] Detox tests pass (only Heap employees are able run these) (Android only, see above)
- [ ] If this is a bugfix/feature, the changelog has been updated (Alpha release, so no changelog update)
