### PR TITLE
Include react native version with other telemetry props [S]

### DIFF
--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -63,6 +63,7 @@ describe('The Heap object', () => {
     NavigationUtil.getScreenPropsForCurrentRoute.mockImplementation(() => {
       return {
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         screen_path: 'Basics::Foo',
         screen_name: 'Foo',
         source_version: SDK_VERSION,
@@ -77,6 +78,7 @@ describe('The Heap object', () => {
       expect(mockTrack.mock.calls[0][1]).toEqual(expectedProps);
       expect(mockTrack.mock.calls[0][2]).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         screen_path: 'Basics::Foo',
         screen_name: 'Foo',
         source_version: SDK_VERSION,

--- a/js/autotrack/__tests__/common.spec.js
+++ b/js/autotrack/__tests__/common.spec.js
@@ -58,6 +58,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@Text;[testID=targetElement];|',
@@ -85,6 +86,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@MySpecialComponent;|@Text;[testID=targetElement];|',
@@ -109,6 +111,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@ListItem;[rightTitle=React.element];|@Text;[testID=targetElement];|',
@@ -151,6 +154,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|',
@@ -178,6 +182,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;|',
@@ -205,6 +210,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;[testID=targetElement];|',
         source_version: SDK_VERSION,
@@ -234,6 +240,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         target_text: 'foobar',
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@Text;[testID=targetElement];|',
@@ -270,6 +277,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnore;|@BarFunction;|@HeapIgnore;|',
         source_version: SDK_VERSION,
@@ -294,6 +302,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@withHeapIgnore(Text);[testID=targetElement];|@HeapIgnore;|@Text;|',
         source_version: SDK_VERSION,
@@ -316,6 +325,7 @@ describe('Common autotrack utils', () => {
       );
       expect(normalProps).toEqual({
         is_using_react_navigation_hoc: false,
+        react_native_version: null,
         rn_hierarchy:
           '@WrapperComponent;|@Foo;|@BarClass;|@BarFunction;|@HeapIgnoreTargetText;|@HeapIgnore;|@Text;[testID=targetElement];|',
         source_version: SDK_VERSION,

--- a/js/util/metadataPropUtil.ts
+++ b/js/util/metadataPropUtil.ts
@@ -1,10 +1,21 @@
 import NavigationUtil from './navigationUtil';
 
+const { Platform } = require('react-native');
+
 const { version } = require('../../package.json');
+
+let reactNativeVersionString: String | null = null;
+
+if (Platform && Platform.constants && Platform.constants.reactNativeVersion) {
+  const { major, minor, patch } = Platform.constants.reactNativeVersion;
+
+  reactNativeVersionString = `${major}.${minor}.${patch}`;
+}
 
 export const getMetadataProps = () => {
   return {
     source_version: version,
     is_using_react_navigation_hoc: NavigationUtil.isHocEnabled(),
+    react_native_version: reactNativeVersionString,
   };
 };


### PR DESCRIPTION
## Description
Include a `react_native_version` telemetry metadata prop on React Native events.  Note that this will _not_ work on React Native versions below 0.61, since that's the first version with the `Platform.constants` API (see tags associated with https://github.com/facebook/react-native/commit/7fd08e146184432731ec5d5ba210e352690dc569).

## Test Plan
* Ran Android e2e tests to confirm this doesn't lead to any regressions on older versions of RN.
* Ran this on an android app with a newer version of React Native, and confirmed that `react_native_version` is included as a source property with an accurate value.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these) (ran Android; iOS shouldn't be any different)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (not a feature)
