### PR TITLE
HOC instrumentation for TextInput on RN 0.62+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
 - Added support for `Touchable` components in React Native v0.62+ via HOC instrumentation.
+- Added support for `TextInput` components in React Native v0.62+ via HOC instrumentation.
 - Added support for React Navigation 5.
 
 ### Changed

--- a/examples/TestDriverRN063/package-lock.json
+++ b/examples/TestDriverRN063/package-lock.json
@@ -872,7 +872,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:heap-react-native-heap-0.13.0-alpha2.tgz",
-      "integrity": "sha512-i/+32ax46/Ob15ZCUgkoz6Ap/SrrjJAgVptYvXp6xisE1WB3VDNlFwRnmGxXZhRrTMNzf5c9EMc6D8Xn0/Pz2Q==",
+      "integrity": "sha512-1buZsJ52RtqVn4VFGHJTNqsCdAnMAymAsrHROdiO3R77Ol7724IRQQTzfWGwLJ6R7/3+VD0Oezp6h9K1KU/tlQ==",
       "requires": {
         "@babel/core": "^7.2.2",
         "@types/react-reconciler": "^0.18.0",

--- a/examples/TestDriverRN063/src/screens/TouchablesScreen.tsx
+++ b/examples/TestDriverRN063/src/screens/TouchablesScreen.tsx
@@ -1,5 +1,17 @@
 import React from 'react';
-import { Button, TouchableOpacity, ScrollView, Text } from 'react-native';
+import { Button, TouchableOpacity, ScrollView, Text, TextInput } from 'react-native';
+
+const MyTextInput = () => {
+  const [value, onChangeText] = React.useState();
+
+  return (
+    <TextInput
+      style={{ height: 40, borderColor: 'gray', borderWidth: 1 }}
+      onChangeText={text => onChangeText(text)}
+      value={value}
+    />
+  );
+}
 
 export const TouchablesScreen = () => {
   return (
@@ -9,6 +21,7 @@ export const TouchablesScreen = () => {
         onPress={() => console.log('pressed touchable opacity')}>
         <Text>Touchable Opacity</Text>
       </TouchableOpacity>
+      <MyTextInput />
     </ScrollView>
   );
 };

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -351,16 +351,16 @@ const instrumentTextInputHoc = path => {
     path.node.body
   );
 
+  const hocIdentifier = t.identifier('withHeapTextInputAutocapture');
+
   const autotrackExpression = t.callExpression(
-    t.memberExpression(
-      t.identifier('Heap'),
-      t.identifier('withHeapTextInputAutocapture')
-    ),
+    t.memberExpression(t.identifier('Heap'), hocIdentifier),
     [equivalentExpression]
   );
 
   const replacement = buildInstrumentationHoc({
     COMPONENT_ID: path.node.id,
+    HOC_IDENTIFIER: hocIdentifier,
     HOC_CALL_EXPRESSION: autotrackExpression,
   });
 

--- a/instrumentor/test/fixtures/is-functional-textinput/code.js
+++ b/instrumentor/test/fixtures/is-functional-textinput/code.js
@@ -1,0 +1,1 @@
+function InternalTextInput(props: Props): React.Node {}

--- a/instrumentor/test/fixtures/is-functional-textinput/output.js
+++ b/instrumentor/test/fixtures/is-functional-textinput/output.js
@@ -1,0 +1,3 @@
+var Heap = require('@heap/react-native-heap').default;
+
+var InternalTextInput = Heap.withHeapTextInputAutocapture(function InternalTextInput(props) {});

--- a/instrumentor/test/fixtures/is-functional-textinput/output.js
+++ b/instrumentor/test/fixtures/is-functional-textinput/output.js
@@ -1,3 +1,6 @@
-var Heap = require('@heap/react-native-heap').default;
-
+var Heap = require('@heap/react-native-heap').default || {
+  withHeapTextInputAutocapture: function withHeapTextInputAutocapture(Component) {
+    return Component;
+  }
+};
 var InternalTextInput = Heap.withHeapTextInputAutocapture(function InternalTextInput(props) {});

--- a/instrumentor/test/index.js
+++ b/instrumentor/test/index.js
@@ -77,6 +77,12 @@ describe('autotrack instrumentor plugin', () => {
     var expected = getExpectedTransformedFile('is-touchable-0-62');
     assert.equal(actual, expected);
   });
+
+  it('functional textinput should be instrumented with HOC', () => {
+    var actual = getActualTransformedFile('is-functional-textinput');
+    var expected = getExpectedTransformedFile('is-functional-textinput');
+    assert.equal(actual, expected);
+  });
 });
 
 const getActualTransformedFile = fixtureName => {

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -13,7 +13,10 @@ import {
 } from './autotrack/touchables';
 import { autotrackSwitchChange } from './autotrack/switches';
 import { autotrackScrollView } from './autotrack/scrollViews';
-import { autocaptureTextInputChange } from './autotrack/textInput';
+import {
+  autocaptureTextInputChange,
+  withHeapTextInputAutocapture,
+} from './autotrack/textInput';
 import { checkDisplayNamePlugin } from './util/checkDisplayNames';
 import { withReactNavigationAutotrack } from './autotrack/reactNavigation';
 import { bailOnError } from './util/bailer';
@@ -90,6 +93,7 @@ export default {
   autocaptureTextInput: bailOnError(
     autocaptureTextInputChange(autocaptureTrack)
   ),
+  withHeapTextInputAutocapture: withHeapTextInputAutocapture(autocaptureTrack),
   withReactNavigationAutotrack: withReactNavigationAutotrack(autocaptureTrack),
   Ignore: HeapIgnore,
   IgnoreTargetText: HeapIgnoreTargetText,

--- a/js/autotrack/textInput.js
+++ b/js/autotrack/textInput.js
@@ -80,7 +80,7 @@ export const withHeapTextInputAutocapture = track => TextInputComponent => {
     }
   }
 
-  HeapTextInputAutocapture.displayName = `withHeapTextInputAutocapture(${getComponentDisplayName(
+  HeapTextInputAutocapture.displayName = `WithHeapTextInputAutocapture(${getComponentDisplayName(
     TextInputComponent
   )})`;
 


### PR DESCRIPTION
## Description
This is similar to https://github.com/heap/react-native-heap/pull/207 in that it adds HOC-based instrumentation for `TextInput` components.

Starting with RN 0.62, the internal implementation of the React Native `TextInput` component uses a functional component and React Hooks (this used to be a stateful class component).  Because of this, support for this component in RN 0.62+ would require new instrumentation (not as complicated as non-HOC `Touchable` support, but still non-trivial), making this instrumentation fix a candidate for the HOC-based instrumentation approach.

The instrumentation looks for a function named `InternalTextInput` and wraps it with an HOC.  I.e.
```
function InternalTextInput(props: Props): React.Node {}
```
becomes
```
const Heap = require('@heap/react-native-heap').default;

const InternalTextInput = Heap.withHeapTextInputAutocapture(function InternalTextInput(props) {});
```
(see the test cases).

This is based on https://github.com/heap/react-native-heap/pull/207, so when https://github.com/heap/react-native-heap/pull/207 lands, this branch will need to be rebased onto `develop`, and this PR's base will need to be changed to `develop`.

## Test Plan
* Added instrumentation test case
* Ran e2e tests on the 0.57 test app to ensure no regressions
* Manually triggered text change on 0.62 test app, and verified debounced text change events.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these) (android only)
- [X] If this is a bugfix/feature, the changelog has been updated
