### PR TITLE
[HEAP-16942] No-op when Heap is undefined in instrumentor

### DIFF
--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -327,10 +327,7 @@ const instrumentTouchableHoc = path => {
   const hocIdentifier = t.identifier('withHeapTouchableAutocapture');
 
   const autotrackExpression = t.callExpression(
-    t.memberExpression(
-      t.identifier('Heap'),
-      hocIdentifier
-    ),
+    t.memberExpression(t.identifier('Heap'), hocIdentifier),
     [equivalentExpression]
   );
 

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -21,7 +21,10 @@ const buildStartupWrapper = template(`{
 }`);
 
 const buildInstrumentationHoc = template(`
-  const Heap = require('@heap/react-native-heap').default;
+  const Heap = require('@heap/react-native-heap').default || {
+    HOC_IDENTIFIER: (Component) => Component,
+  };
+
   const COMPONENT_ID = HOC_CALL_EXPRESSION;
 `);
 
@@ -321,16 +324,19 @@ const instrumentTouchableHoc = path => {
     path.node.decorators || []
   );
 
+  const hocIdentifier = t.identifier('withHeapTouchableAutocapture');
+
   const autotrackExpression = t.callExpression(
     t.memberExpression(
       t.identifier('Heap'),
-      t.identifier('withHeapTouchableAutocapture')
+      hocIdentifier
     ),
     [equivalentExpression]
   );
 
   const replacement = buildInstrumentationHoc({
     COMPONENT_ID: path.node.id,
+    HOC_IDENTIFIER: hocIdentifier,
     HOC_CALL_EXPRESSION: autotrackExpression,
   });
 

--- a/instrumentor/test/fixtures/is-touchable-0-62/output.js
+++ b/instrumentor/test/fixtures/is-touchable-0-62/output.js
@@ -8,8 +8,11 @@ var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/ge
 
 var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 
-var Heap = require('@heap/react-native-heap').default;
-
+var Heap = require('@heap/react-native-heap').default || {
+  withHeapTouchableAutocapture: function withHeapTouchableAutocapture(Component) {
+    return Component;
+  }
+};
 var TouchableOpacity = Heap.withHeapTouchableAutocapture(function (_React$Component) {
   (0, _inherits2.default)(TouchableOpacity, _React$Component);
 


### PR DESCRIPTION
## Description
In some cases (most likely just isolated unit tests), `require('@heap/react-native-heap').default` will be undefined.  Currently, we do not handle this case, so tests in which this happens end up crashing.

Instead, stub out the method with a no-op for that particular HOC.  For example, instead of
```
const Heap = require('@heap/react-native-heap').default;

const TouchableOpacity = Heap.withHeapTouchableAutocapture(class Touchable Opacity {...});
```
we would get
```
const Heap = require('@heap/react-native-heap').default || {
  withHeapTouchableAutocapture: (Component) => Component,
};

const TouchableOpacity = Heap.withHeapTouchableAutocapture(class Touchable Opacity {...});
```
such that the HOC will simply return the original component.

## Test Plan
I couldn't get a local repro of `require('@heap/react-native-heap').default` being undefined, so I replaced `require('@heap/react-native-heap').default` with `undefined`, confirmed that this reproduced an error similar to the support issue we were seeing, made this change, then confirmed that the issue would no longer occur (albeit with Heap not capturing Touchables).

## Checklist
- [X] Detox tests pass (only Heap employees are able run these) (android only)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (N/A, fixes issue with prerelease)
