### PR TITLE
[HEAP-17696] Fix instrumentation build failure on id-less function declarations

### DIFF
--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -341,7 +341,7 @@ const instrumentTouchableHoc = path => {
 };
 
 const instrumentTextInputHoc = path => {
-  if (path.node.id.name !== 'InternalTextInput') {
+  if (!path.node.id || path.node.id.name !== 'InternalTextInput') {
     return;
   }
 

--- a/instrumentor/test/fixtures/is-function-declaration-no-id/code.js
+++ b/instrumentor/test/fixtures/is-function-declaration-no-id/code.js
@@ -1,0 +1,1 @@
+export default function() {}

--- a/instrumentor/test/fixtures/is-function-declaration-no-id/output.js
+++ b/instrumentor/test/fixtures/is-function-declaration-no-id/output.js
@@ -1,0 +1,6 @@
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = _default;
+
+function _default() {}

--- a/instrumentor/test/index.js
+++ b/instrumentor/test/index.js
@@ -83,6 +83,12 @@ describe('autotrack instrumentor plugin', () => {
     var expected = getExpectedTransformedFile('is-functional-textinput');
     assert.equal(actual, expected);
   });
+
+  it('function declarations without ID field should not crash instrumentor', () => {
+    var actual = getActualTransformedFile('is-function-declaration-no-id');
+    var expected = getExpectedTransformedFile('is-function-declaration-no-id');
+    assert.equal(actual, expected);
+  });
 });
 
 const getActualTransformedFile = fixtureName => {


### PR DESCRIPTION
## Description
Fixes a bug introduced with the TextInput HOC-based instrumentation in which the presence of a `FunctionDeclaration` without an `id` (as is the case for declarations like `export default function() {}`) would cause the instrumentor to crash.

Check whether `id` on `FunctionDeclaration`s is present, and add tests for this case.

## Test Plan
- Added instrumentor test case
- Ran Android detox tests

## Checklist
- [X] Detox tests pass (only Heap employees are able run these) (Android only)
- [ ] ~If this is a bugfix/feature, the changelog has been updated~ (N/A)
