### PR TITLE
Fix ref-forwarding on TextInput HOC for RN 0.62+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed bug that broke ref-forwarding on `TextInput` components on React Native v0.62+.
+
 ### Security
 __END_UNRELEASED__
 

--- a/examples/TestDriverRN063/package-lock.json
+++ b/examples/TestDriverRN063/package-lock.json
@@ -872,7 +872,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:heap-react-native-heap-0.13.0.tgz",
-      "integrity": "sha512-HKX5QVasKTh/eDVyc4eU527KpcCrLgR6sqiNhjxZ6oyEjekBGVjgmvKkNJ77c3TxjDtQVbsbkrCT7M6K8vCe1g==",
+      "integrity": "sha512-57s0awmYG1T0bZCE4SbsH2i1BC8qyVDUysHlfnBqDxFnD2uXMzXLGmMzIQ/amzD+VzoPNAPCnkAR1tg2CiXDhQ==",
       "requires": {
         "@babel/core": "^7.2.2",
         "@types/react-reconciler": "^0.18.0",

--- a/examples/TestDriverRN063/src/screens/TouchablesScreen.tsx
+++ b/examples/TestDriverRN063/src/screens/TouchablesScreen.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { Button, TouchableOpacity, ScrollView, Text, TextInput } from 'react-native';
 
+const myRef = React.createRef();
+
 const MyTextInput = () => {
   const [value, onChangeText] = React.useState();
 
   return (
     <TextInput
+      ref={myRef}
       style={{ height: 40, borderColor: 'gray', borderWidth: 1 }}
       onChangeText={text => onChangeText(text)}
       value={value}
@@ -17,6 +20,7 @@ export const TouchablesScreen = () => {
   return (
     <ScrollView>
       <Button title="Press me" onPress={() => console.log('pressed button')} />
+      <Button title="focus textinput" onPress={() => myRef.current.focus && myRef.current.focus()} />
       <TouchableOpacity
         onPress={() => console.log('pressed touchable opacity')}>
         <Text>Touchable Opacity</Text>

--- a/js/autotrack/textInput.js
+++ b/js/autotrack/textInput.js
@@ -62,11 +62,11 @@ export const withHeapTextInputAutocapture = track => TextInputComponent => {
     );
 
     render() {
-      const { forwardedRef, onChange, ...rest } = this.props;
+      const { heapForwardedRef, onChange, ...rest } = this.props;
 
       return (
         <TextInputComponent
-          ref={forwardedRef}
+          ref={heapForwardedRef}
           onChange={e => {
             this.autocaptureTextInputChangeWithDebounce('text_edit', this, e);
 
@@ -87,7 +87,7 @@ export const withHeapTextInputAutocapture = track => TextInputComponent => {
   const forwardRefHoc = React.forwardRef((props, ref) => {
     return (
       <NoopTextInput {...props}>
-        <HeapTextInputAutocapture {...props} forwardedRef={ref} />
+        <HeapTextInputAutocapture {...props} heapForwardedRef={ref} />
       </NoopTextInput>
     );
   });


### PR DESCRIPTION
## Description
This was surfaced in https://github.com/heap/react-native-heap/pull/208#issuecomment-691510590 after that PR was merged (thanks @emodventures!).

The specific issue is that the react native lib itself does some ref-forwarding for TextInput (https://github.com/facebook/react-native/blob/4a6039c6359ba70f5cca57ceff26c06f2a0de76b/Libraries/Components/TextInput/TextInput.js#L1172), so the `forwardedRef` prop used by the Heap lib's HOC to forward refs was effectively overwriting the `forwardedRef` prop passed into the HOC by the React Native lib.

By changing the name of `forwardedRef` to the namespaced prop `heapForwardedRef`, we'll still handle _direct_ refs to the `InternalTextInput` passed by the RN lib (e.g. if the RN lib did `<InternalTextInput ref={myRef} />`), while allowing _forwarded_ refs passed by the RN lib (i.e. where the RN lib does `<InternalTextInput forwardedRef={forwardedRef} />`) to pass through to the `InternalTextInput` component as a normal prop, as expected.

## Test Plan
Added functionality to the test app to use the `TextInput`'s ref to give the `TextInput` focus, and manually confirmed that this doesn't work without this fix, and that this does works with the fix.

## Checklist
- [ ] ~Detox tests pass (only Heap employees are able run these)~ N/A (detox tests don't apply to v0.62 functionality)
- [X] If this is a bugfix/feature, the changelog has been updated
