### PR TITLE
[HEAP-17331] Disable native iOS capture by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+- Added 'enableNativeTouchEventCapture' config option that controls whether the native iOS SDK captures touch-like events.
+
 ### Changed
 - Upgraded the native Heap iOS SDK dependency to 7.2.0.
 

--- a/examples/TestDriverRN063/ios/TestDriverRN063/AppDelegate.m
+++ b/examples/TestDriverRN063/ios/TestDriverRN063/AppDelegate.m
@@ -45,10 +45,6 @@ static void InitializeFlipper(UIApplication *application) {
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"TestDriverRN063"
                                             initialProperties:nil];
-
-  // Suppress native iOS events to make pixels smaller, reducing flakiness.  See https://github.com/heap/react-native-heap/pull/144.
-  [rootView setValue:@true forKey:@"heapIgnore"];
-
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/examples/TestDriverRN063/package-lock.json
+++ b/examples/TestDriverRN063/package-lock.json
@@ -872,7 +872,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:heap-react-native-heap-0.13.0.tgz",
-      "integrity": "sha512-HI343hzW8yhUx433Mam3DOQzPylaTGbL6PrYz4RocMe68ZM4QiRw3edFd8ZdIDsAuKpYaIcnaWRKk1aa0kkIGg==",
+      "integrity": "sha512-56LDi8cyPJ4Fl9dSFPgJLcaa4u7WB43KJ+ARaF3kT2UT8QgSw7D6S9lEY6E2ve9O1Dux9IxQJbSi3ScncoUNpQ==",
       "requires": {
         "@babel/core": "^7.2.2",
         "@types/react-reconciler": "^0.18.0",

--- a/examples/TestDriverRN063/package-lock.json
+++ b/examples/TestDriverRN063/package-lock.json
@@ -872,7 +872,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:heap-react-native-heap-0.13.0.tgz",
-      "integrity": "sha512-57s0awmYG1T0bZCE4SbsH2i1BC8qyVDUysHlfnBqDxFnD2uXMzXLGmMzIQ/amzD+VzoPNAPCnkAR1tg2CiXDhQ==",
+      "integrity": "sha512-HI343hzW8yhUx433Mam3DOQzPylaTGbL6PrYz4RocMe68ZM4QiRw3edFd8ZdIDsAuKpYaIcnaWRKk1aa0kkIGg==",
       "requires": {
         "@babel/core": "^7.2.2",
         "@types/react-reconciler": "^0.18.0",

--- a/ios/HeapSettings.bundle/HeapSettings.plist.template
+++ b/ios/HeapSettings.bundle/HeapSettings.plist.template
@@ -6,5 +6,9 @@
 	<string>__HEAP_APP_ID_DEV__</string>
 	<key>HeapAppIdProd</key>
 	<string>__HEAP_APP_ID_PROD__</string>
+	<key>HeapEnableAutocaptureDev</key>
+	<string>__HEAP_ENABLE_AUTOCAPTURE_DEV__</string>
+	<key>HeapEnableAutocaptureProd</key>
+	<string>__HEAP_ENABLE_AUTOCAPTURE_PROD__</string>
 </dict>
 </plist>

--- a/ios/HeapSettings.bundle/generate_settings.rb
+++ b/ios/HeapSettings.bundle/generate_settings.rb
@@ -30,15 +30,19 @@ def write_heap_settings
   if File.file?(settings_filename)
     json = JSON.parse File.read(settings_filename).strip
 
-    app_id_dev, app_id_prod = get_heap_settings_from_json(json)
+    perform_substitution BUNDLE_DIRECTORY, json
+
+    if APP_DIRECTORY && File.directory?(APP_DIRECTORY)
+      perform_substitution APP_DIRECTORY, json
+    end
   else
     puts "Not auto-initializing Heap; couldn't find #{HEAP_CONFIG_FILENAME}."
-  end
 
-  perform_substitution BUNDLE_DIRECTORY, app_id_dev, app_id_prod
+    perform_empty_substitution BUNDLE_DIRECTORY
 
-  if APP_DIRECTORY && File.directory?(APP_DIRECTORY)
-    perform_substitution APP_DIRECTORY, app_id_dev, app_id_prod
+    if APP_DIRECTORY && File.directory?(APP_DIRECTORY)
+      perform_empty_substitution APP_DIRECTORY
+    end
   end
 end
 

--- a/ios/HeapSettings.bundle/generate_settings_common.rb
+++ b/ios/HeapSettings.bundle/generate_settings_common.rb
@@ -32,14 +32,14 @@ def perform_empty_substitution(dir)
   IO.write output_path, settings
 end
 
-def get_app_id_for_config(specified_config, default_config)
-  is_auto_init = specified_config['heapAutoInit']
+def get_app_id_for_config(config_for_selected_environment, default_config)
+  is_auto_init = config_for_selected_environment['heapAutoInit']
   is_auto_init = default_config['heapAutoInit'] if is_auto_init.nil?
   is_auto_init = true if is_auto_init.nil?
 
-  return specified_config['heapAppId'] || default_config['heapAppId'] if is_auto_init
+  return config_for_selected_environment['heapAppId'] || default_config['heapAppId'] if is_auto_init
 end
 
-def get_enable_autocapture_for_config(specified_config, default_config)
-  return specified_config['enableNativeTouchEventCapture'] || default_config['enableNativeTouchEventCapture']
+def get_enable_autocapture_for_config(config_for_selected_environment, default_config)
+  return config_for_selected_environment['enableNativeTouchEventCapture'] || default_config['enableNativeTouchEventCapture']
 end

--- a/ios/HeapSettings.bundle/generate_settings_common.rb
+++ b/ios/HeapSettings.bundle/generate_settings_common.rb
@@ -2,23 +2,34 @@
 
 require 'fileutils'
 
-def perform_substitution(dir, app_id_dev, app_id_prod)
-  template = File.read File.join(dir, 'HeapSettings.plist.template')
-  output_path = File.join dir, 'HeapSettings.plist'
-
-  settings = template
-    .gsub('__HEAP_APP_ID_DEV__', app_id_dev || '')
-    .gsub('__HEAP_APP_ID_PROD__', app_id_prod || '')
-
-  IO.write output_path, settings
-end
-
-def get_heap_settings_from_json(json)
+def perform_substitution(dir, json)
   dev = json.fetch('dev', {})
   prod = json.fetch('prod', {})
   default = json.fetch('default', {})
 
-  return get_app_id_for_config(dev, default), get_app_id_for_config(prod, default)
+  template = File.read File.join(dir, 'HeapSettings.plist.template')
+  output_path = File.join dir, 'HeapSettings.plist'
+
+  settings = template
+    .gsub('__HEAP_APP_ID_DEV__', get_app_id_for_config(dev, default) || '')
+    .gsub('__HEAP_APP_ID_PROD__', get_app_id_for_config(prod, default) || '')
+    .gsub('__HEAP_ENABLE_AUTOCAPTURE_DEV__', get_enable_autocapture_for_config(dev, default) ? 'true' : 'false')
+    .gsub('__HEAP_ENABLE_AUTOCAPTURE_PROD__', get_enable_autocapture_for_config(prod, default) ? 'true' : 'false')
+
+  IO.write output_path, settings
+end
+
+def perform_empty_substitution(dir)
+  template = File.read File.join(dir, 'HeapSettings.plist.template')
+  output_path = File.join dir, 'HeapSettings.plist'
+
+  settings = template
+    .gsub('__HEAP_APP_ID_DEV__', '')
+    .gsub('__HEAP_APP_ID_PROD__', '')
+    .gsub('__HEAP_ENABLE_AUTOCAPTURE_DEV__', 'false')
+    .gsub('__HEAP_ENABLE_AUTOCAPTURE_PROD__', 'false')
+
+  IO.write output_path, settings
 end
 
 def get_app_id_for_config(specified_config, default_config)
@@ -27,4 +38,8 @@ def get_app_id_for_config(specified_config, default_config)
   is_auto_init = true if is_auto_init.nil?
 
   return specified_config['heapAppId'] || default_config['heapAppId'] if is_auto_init
+end
+
+def get_enable_autocapture_for_config(specified_config, default_config)
+  return specified_config['enableNativeTouchEventCapture'] || default_config['enableNativeTouchEventCapture']
 end

--- a/ios/HeapSettings.bundle/generate_settings_non_cocoapods.rb
+++ b/ios/HeapSettings.bundle/generate_settings_non_cocoapods.rb
@@ -20,12 +20,12 @@ def write_heap_settings
   if File.file?(settings_filename)
     json = JSON.parse File.read(settings_filename).strip
 
-    app_id_dev, app_id_prod = get_heap_settings_from_json(json)
+    perform_substitution __dir__, json
   else
     puts "Not auto-initializing Heap; couldn't find #{HEAP_CONFIG_FILENAME}."
-  end
 
-  perform_substitution __dir__, app_id_dev, app_id_prod
+    perform_empty_substitution __dir__
+  end
 end
 
 write_heap_settings

--- a/ios/RNHeapInit.m
+++ b/ios/RNHeapInit.m
@@ -18,7 +18,7 @@
     #endif
 
     if ([heapAppId length] > 0) {
-        NSLog(@"Auto-initializing the Heap library with app ID %@.", heapAppId, enableAutocapture);
+        NSLog(@"Auto-initializing the Heap library with app ID %@ with native autocapture enabled=%@.", heapAppId, enableAutocapture);
 
         HeapOptions *options = [[HeapOptions alloc] init];
         if (![enableAutocapture isEqualToString:@"true"]) {

--- a/ios/RNHeapInit.m
+++ b/ios/RNHeapInit.m
@@ -11,13 +11,21 @@
 
     #ifdef DEBUG
         NSString *heapAppId = heapPlistData[@"HeapAppIdDev"];
+        NSString *enableAutocapture = heapPlistData[@"HeapEnableAutocaptureDev"];
     #else
         NSString *heapAppId = heapPlistData[@"HeapAppIdProd"];
+        NSString *enableAutocapture = heapPlistData[@"HeapEnableAutocaptureProd"];
     #endif
 
     if ([heapAppId length] > 0) {
-        NSLog(@"Auto-initializing the Heap library with app ID %@.", heapAppId);
-        [Heap setAppId:heapAppId];
+        NSLog(@"Auto-initializing the Heap library with app ID %@.", heapAppId, enableAutocapture);
+
+        HeapOptions *options = [[HeapOptions alloc] init];
+        if (![enableAutocapture isEqualToString:@"true"]) {
+            options.disableTouchAutocapture = YES;
+        }
+
+        [Heap initialize:heapAppId withOptions:options];
     } else {
         NSLog(@"Not auto-initializing Heap library.");
     }


### PR DESCRIPTION
## Description
Add an `enableNativeTouchEventCapture` option for `heap.config.json` that defaults to `false`.  This flag determines whether events captured by the native iOS SDK (which are generally superfluous to events captured by the RN SDK, and are almost always unusable) will be processed.  This is intended to replace the need for `heapIgnore` as described in the [React Native iOS install docs](https://developers.heap.io/docs/react-native#ios-1) while ensuring that views created outside the root view (as is the case for certain modals) will also be ignored by the native iOS SDK.

In cases where parts of an app are implemented as native iOS views, `enableNativeTouchEventCapture` should be set to true, and `heapIgnore` should still be set on the root view.

This feature builds on the functionality implemented for auto-initialization (which assumed only `heapAutoInit` and `heapAppId` config props), so there may be on opportunity for a better refactor that allows for better extensibility to additional options.  I'm open to suggestions.

## Test Plan
Manually tested auto-initialization with and without `enableNativeTouchEventCapture` set, and confirmed that native iOS events did or didn't come through.

## Checklist
- [ ] ~Detox tests pass (only Heap employees are able run these)~ (N/A)
- [X] If this is a bugfix/feature, the changelog has been updated
