### PR TITLE
[HEAP-18197] Bump version to 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+__END_UNRELEASED__
+
+
+## [0.14.0] - 2020-09-23
+### Added
 - Added 'enableNativeTouchEventCapture' config option that controls whether the native iOS SDK captures touch-like events.
 
 ### Changed
 - Upgraded the native Heap iOS SDK dependency to 7.2.0.
 
-### Deprecated
-### Removed
 ### Fixed
 - Fixed bug that broke ref-forwarding on `TextInput` components on React Native v0.62+.
-
-### Security
-__END_UNRELEASED__
 
 ## [0.13.0] - 2020-08-31
 

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - glog (0.3.5)
   - React (0.57.5):
     - React/Core (= 0.57.5)
-  - react-native-heap (0.13.0):
+  - react-native-heap (0.14.0):
     - React
   - React/Core (0.57.5):
     - yoga (= 0.57.5.React)
@@ -106,7 +106,7 @@ SPEC CHECKSUMS:
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   React: 01aa04500b2957c2767e1dff9fe12e09444a467c
-  react-native-heap: 27a85f761033d68e8ddcb7e159ea9ad39b0f0cde
+  react-native-heap: c9924c2f98e9c48e6a8ce86c0a114c896900aec2
   RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
   yoga: a5c0ba30ebe82c13612b4c9301ad29708b8978dc
 

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "../preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.13.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.14.0.tgz",
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",

--- a/examples/TestDriverRN063/ios/Podfile.lock
+++ b/examples/TestDriverRN063/ios/Podfile.lock
@@ -236,7 +236,7 @@ PODS:
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
-  - react-native-heap (0.13.0):
+  - react-native-heap (0.14.0):
     - React
   - react-native-safe-area-context (3.1.1):
     - React
@@ -475,7 +475,7 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-heap: 27a85f761033d68e8ddcb7e159ea9ad39b0f0cde
+  react-native-heap: c9924c2f98e9c48e6a8ce86c0a114c896900aec2
   react-native-safe-area-context: 4c3249e4840225c61fcd215b136af0a737bccb79
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6

--- a/examples/TestDriverRN063/package-lock.json
+++ b/examples/TestDriverRN063/package-lock.json
@@ -871,8 +871,8 @@
       }
     },
     "@heap/react-native-heap": {
-      "version": "file:heap-react-native-heap-0.13.0.tgz",
-      "integrity": "sha512-56LDi8cyPJ4Fl9dSFPgJLcaa4u7WB43KJ+ARaF3kT2UT8QgSw7D6S9lEY6E2ve9O1Dux9IxQJbSi3ScncoUNpQ==",
+      "version": "file:heap-react-native-heap-0.14.0.tgz",
+      "integrity": "sha512-BPJNUeERo+L2jdBPAXGZSDRsOmKZJPtyKjd3sNn92+9gcUSDZ89zudFd3vvtF/qAA1ZAaVSpAms5EodDnrwJHA==",
       "requires": {
         "@babel/core": "^7.2.2",
         "@types/react-reconciler": "^0.18.0",

--- a/examples/TestDriverRN063/package.json
+++ b/examples/TestDriverRN063/package.json
@@ -11,7 +11,7 @@
     "preinstall": "../preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.13.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.14.0.tgz",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
## Description
Bump version to 0.14.0.  Android detox tests pass, but I still need to manually test Android and iOS on the newer RN 0.63 test app.

## Test Plan
* Android detox tests pass
* Manually test iOS and Android on new test app

## Checklist
- [X] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
