### PR TITLE
[HEAP-16842] Pressable component support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+- Added support for `Pressable` components (introduced in React Native v0.63) via HOC instrumentation.
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/examples/TestDriverRN063/src/screens/TouchablesScreen.tsx
+++ b/examples/TestDriverRN063/src/screens/TouchablesScreen.tsx
@@ -25,7 +25,7 @@ export const TouchablesScreen = () => {
         onPress={() => console.log('pressed touchable opacity')}>
         <Text>Touchable Opacity</Text>
       </TouchableOpacity>
-      <Pressable onPress={() => console.log('pressed pressable')}>
+      <Pressable onPress={() => console.log('pressed pressable')} onPressIn={() => console.log('pressed in pressable')}>
         <Text>Pressable</Text>
       </Pressable>
       <MyTextInput />

--- a/examples/TestDriverRN063/src/screens/TouchablesScreen.tsx
+++ b/examples/TestDriverRN063/src/screens/TouchablesScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button, TouchableOpacity, ScrollView, Text, TextInput } from 'react-native';
+import { Button, Pressable, TouchableOpacity, ScrollView, Text, TextInput } from 'react-native';
 
 const myRef = React.createRef();
 
@@ -25,6 +25,9 @@ export const TouchablesScreen = () => {
         onPress={() => console.log('pressed touchable opacity')}>
         <Text>Touchable Opacity</Text>
       </TouchableOpacity>
+      <Pressable onPress={() => console.log('pressed pressable')}>
+        <Text>Pressable</Text>
+      </Pressable>
       <MyTextInput />
     </ScrollView>
   );

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -24,7 +24,7 @@ const buildHeapImport = template(`(
   require('@heap/react-native-heap').default || {
     HOC_IDENTIFIER: (Component) => Component,
   }
-)`)
+)`);
 
 const buildInstrumentationHoc = template(`
   const Heap = HEAP_IMPORT;
@@ -396,7 +396,7 @@ const instrumentPressableHoc = path => {
   );
 
   path.get('init').replaceWith(autotrackExpression);
-}
+};
 
 function transform(babel) {
   return {
@@ -418,7 +418,7 @@ function transform(babel) {
       },
       VariableDeclarator(path) {
         instrumentPressableHoc(path);
-      }
+      },
     },
   };
 }

--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -380,6 +380,9 @@ const instrumentTextInputHoc = path => {
 };
 
 const instrumentPressableHoc = path => {
+  // 'MemoedPressable' is the component that actually gets exported from 'Pressable.js' in the react-native library, so wrap that instead of
+  // the 'Pressable' component defined in that file.
+  // See https://github.com/facebook/react-native/blob/2c896d35782cd04c873aefadc947447cc30a7f60/Libraries/Components/Pressable/Pressable.js#L242-L245.
   if (!path.node.id || path.node.id.name !== 'MemoedPressable') {
     return;
   }

--- a/instrumentor/test/fixtures/is-pressable/code.js
+++ b/instrumentor/test/fixtures/is-pressable/code.js
@@ -1,0 +1,1 @@
+const MemoedPressable = React.memo(React.forwardRef(Pressable));

--- a/instrumentor/test/fixtures/is-pressable/output.js
+++ b/instrumentor/test/fixtures/is-pressable/output.js
@@ -1,0 +1,5 @@
+var MemoedPressable = (require('@heap/react-native-heap').default || {
+  withHeapPressableAutocapture: function withHeapPressableAutocapture(Component) {
+    return Component;
+  }
+}).withHeapPressableAutocapture(React.memo(React.forwardRef(Pressable)));

--- a/instrumentor/test/index.js
+++ b/instrumentor/test/index.js
@@ -89,6 +89,12 @@ describe('autotrack instrumentor plugin', () => {
     var expected = getExpectedTransformedFile('is-function-declaration-no-id');
     assert.equal(actual, expected);
   });
+
+  it('pressable components should be instrumented', () => {
+    var actual = getActualTransformedFile('is-pressable');
+    var expected = getExpectedTransformedFile('is-pressable');
+    assert.equal(actual, expected);
+  });
 });
 
 const getActualTransformedFile = fixtureName => {

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -11,6 +11,7 @@ import {
   autotrackPress,
   withHeapTouchableAutocapture,
 } from './autotrack/touchables';
+import { withHeapPressableAutocapture } from './autotrack/pressable';
 import { autotrackSwitchChange } from './autotrack/switches';
 import { autotrackScrollView } from './autotrack/scrollViews';
 import {
@@ -88,6 +89,7 @@ export default {
 
   autotrackPress: bailOnError(autotrackPress(autocaptureTrack)),
   withHeapTouchableAutocapture: withHeapTouchableAutocapture(autocaptureTrack),
+  withHeapPressableAutocapture: withHeapPressableAutocapture(autocaptureTrack),
   autotrackSwitchChange: bailOnError(autotrackSwitchChange(autocaptureTrack)),
   autocaptureScrollView: bailOnError(autotrackScrollView(autocaptureTrack)),
   autocaptureTextInput: bailOnError(

--- a/js/autotrack/pressable.js
+++ b/js/autotrack/pressable.js
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import hoistNonReactStatic from 'hoist-non-react-statics';
+
+import { getBaseComponentProps } from './common';
+import { bailOnError } from '../util/bailer';
+import { getComponentDisplayName } from '../util/hocUtil';
+
+export const autotrackPress = track => (eventType, componentThis, event) => {
+};
+
+export const withHeapPressableAutocapture = track => PressableComponent => {
+  class HeapPressableAutocapture extends React.Component {
+    trackEvent(isLongPress) {
+      const autotrackProps = getBaseComponentProps(this);
+
+      if (!autotrackProps) {
+        // We're not capturing this interaction.
+        return;
+      }
+
+      autotrackProps.is_long_press = isLongPress;
+
+      track('touch', autotrackProps);
+    }
+
+    render() {
+      const { heapForwardedRef, onPress, onLongPress, ...rest } = this.props;
+
+      return (
+        <PressableComponent
+          ref={heapForwardedRef}
+          onPress={e => {
+            bailOnError(() => this.trackEvent(false))();
+
+            onPress && onPress(e);
+          }}
+          onLongPress={e => {
+            bailOnError(() => this.trackEvent(true))();
+
+            onLongPress && onLongPress(e);
+          }}
+          {...rest}
+        >
+          {this.props.children}
+        </PressableComponent>
+      );
+    }
+  }
+
+  HeapPressableAutocapture.displayName = `withHeapPressableAutocapture(${getComponentDisplayName(
+    PressableComponent
+  )})`;
+
+  const forwardRefHoc = React.forwardRef((props, ref) => {
+    return <HeapPressableAutocapture {...props} heapForwardedRef={ref} />;
+  });
+
+  hoistNonReactStatic(forwardRefHoc, PressableComponent);
+
+  return forwardRefHoc;
+};

--- a/js/autotrack/pressable.js
+++ b/js/autotrack/pressable.js
@@ -5,9 +5,6 @@ import { getBaseComponentProps } from './common';
 import { bailOnError } from '../util/bailer';
 import { getComponentDisplayName } from '../util/hocUtil';
 
-export const autotrackPress = track => (eventType, componentThis, event) => {
-};
-
 export const withHeapPressableAutocapture = track => PressableComponent => {
   class HeapPressableAutocapture extends React.Component {
     trackEvent(isLongPress) {


### PR DESCRIPTION
## Description
Adds support for `Pressable` components (introduced in RN 0.63) via HOC instrumentation.

## Test Plan
* Manually tested Android and iOS for RN 0.63.
* Android E2E detox tests on RN 0.57.

## Checklist
- [X] Detox tests pass (only Heap employees are able run these) (Android only)
- [X] If this is a bugfix/feature, the changelog has been updated
