### PR TITLE
Rn android/fix/heap 20927 try test harness

### DIFF
--- a/e2e/basics.spec.js
+++ b/e2e/basics.spec.js
@@ -66,6 +66,11 @@ const doTestActions = async () => {
   await rnTestUtil.waitIfIos();
 
   await element(by.id('scrollView')).swipe('left');
+  // Depending on device dimensions, the Basics Sentinel button can be obscured by the bottom navigation tab.
+  // A click on the button can inadvertently trigger a navigation change to a different part of the app. In
+  // order to avoid that, we bring the Basics Sentinel button safely above the navigation tab by scrolling
+  // down.
+  await element(by.id('scrollContainer')).scrollTo('bottom');
   await element(by.id('basicsSentinel')).tap();
 };
 

--- a/examples/TestDriver/android/app/build.gradle
+++ b/examples/TestDriver/android/app/build.gradle
@@ -109,6 +109,7 @@ android {
         }
         testBuildType System.getProperty('testBuildType', 'debug')  //this will later be used to control the test apk build type
         missingDimensionStrategy "minReactNative", "minReactNative46" //read note
+        missingDimensionStrategy 'detox', 'full'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     splits {
@@ -156,6 +157,8 @@ dependencies {
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
     implementation project(':@heap_react-native-heap')
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test:rules:1.3.0'
     androidTestImplementation(project(path: ":detox"))
     androidTestImplementation 'junit:junit:4.12'
 }

--- a/examples/TestDriver/android/app/src/androidTest/java/com/testdriver/DetoxTest.java
+++ b/examples/TestDriver/android/app/src/androidTest/java/com/testdriver/DetoxTest.java
@@ -6,7 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.runner.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;
 

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "babel-jest": "23.6.0",
-    "detox": "12.1.1",
+    "detox": "18.9.0",
     "jest": "23.6.0",
     "metro-react-native-babel-preset": "0.49.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/node": "^10.12.19",
     "coffeescript": "^1.12.7",
     "deep-freeze": "0.0.1",
-    "detox": "12.1.1",
+    "detox": "18.9.0",
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.12.1",
     "jest": "^24.0.0",


### PR DESCRIPTION
## Heap Customer Support

Thanks for using Heap's React Native SDK! If you're having any issues, please reach out to customer support at <support@heap.io>. For the best service, include "React Native" in the subject and your app id or customer email address in the body. Also, feel free to file a github issue or open a PR! If you do so, be sure to include a link in your request to customer support. Our engineering team checks for new PRs and github issues and tries to respond as soon as possible.

## Description
What does this PR add/fix/change?
- Broken Android E2E test harness.

Is there anything reviewers should pay special attention to?
- No.

Are there any breaking changes?
- No.

## Test Plan
How were these changes tested?
- Was able to get Android E2E tests to build and pass.

Were additional test cases added?
- No.

Was there manual testing?

## Checklist
- [x] Detox tests pass (only Heap employees are able run these)
- [ ] If this is a bugfix/feature, the changelog has been updated
