### PR TITLE
fix: relative path in podspec

### DIFF
--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
 
   s.script_phase = {
     name: 'Generate `HeapSettings.plist`',
-    script: '../../node_modules/@heap/react-native-heap/ios/HeapSettings.bundle/generate_settings.rb',
+    script: '${PODS_TARGET_SRCROOT}/ios/HeapSettings.bundle/generate_settings.rb',
     execution_position: :after_compile,
     shell_path: '/bin/bash'
   }


### PR DESCRIPTION
If a react-native project does not have a traditional file structure, the relative path to `generate_settings.rb` will not be correct. Since there is a user defined build setting for the correct path, just use that.

## Description
What does this PR add/fix/change?
Fixes relative path issue to `generate_settings.rb`
Is there anything reviewers should pay special attention to?
Confirming the user defined build setting is the correct one to use (`PODS_TARGET_SRCROOT`)
Are there any breaking changes?
No

## Test Plan
How were these changes tested?
Locally in a project that implements this package
Were additional test cases added?
No
Was there manual testing?
Yes

## Checklist
- [ ] Detox tests pass (only Heap employees are able run these)
- [ ] If this is a bugfix/feature, the changelog has been updated
