### PR TITLE
React 17 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+- Added support for React 17 (resolves #241).
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -12,6 +12,7 @@ import { stripReservedCharacters } from '../util/reservedCharacters';
 // '_reactInternalFiber' property, so create our own 'Component' type that includes this prop.
 // :TODO: (jmtaber129): Consider pulling this out if other TS files need this extended typing.
 interface Component extends ReactComponent {
+  _reactInternals: FiberNode;
   _reactInternalFiber: FiberNode;
 }
 
@@ -66,7 +67,7 @@ export const getBaseComponentProps: (
   // Only look for target text if we're not HeapIgnore-ing target text.
   let targetText;
   if (heapIgnoreProps.allowTargetText) {
-    targetText = getTargetText(componentThis._reactInternalFiber);
+    targetText = getTargetText(getReactInternalFiber(componentThis));
   } else {
     targetText = '';
   }
@@ -89,15 +90,18 @@ const getComponentHierarchyTraversal: (
   comp: Component
 ) => ComponentHierarchyTraversalElement[] = componentThis => {
   // :TODO: (jmtaber129): Remove this if/when we support pre-fiber React.
-  if (!componentThis._reactInternalFiber) {
+  const fiber = getReactInternalFiber(componentThis);
+  if (!fiber) {
     throw new Error(
       'Pre-fiber React versions (React 16) are currently not supported by Heap autotrack.'
     );
   }
 
-  return getFiberNodeComponentHierarchyTraversal(
-    componentThis._reactInternalFiber
-  );
+  return getFiberNodeComponentHierarchyTraversal(fiber);
+};
+
+const getReactInternalFiber = (comp: Component) => {
+  return comp._reactInternals || comp._reactInternalFiber;
 };
 
 // Traverse up the hierarchy from the current component up to the root, and return an array of


### PR DESCRIPTION
## Description
This add support for React 17. It does this by checking for both the new and old fiber internal value and using the correct one. It should be backwards compatible, but I have currently not tested it on older versions of React.

Fixes #241

## Checklist
- [ ] Detox tests pass (only Heap employees are able run these)
- [X] If this is a bugfix/feature, the changelog has been updated
