### PR TITLE
[HEAP-23268] Bump version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
-- Added support for React 17 (resolves #241).
-
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
 __END_UNRELEASED__
+
+## [0.16.0] - 2021-06-01
+### Added
+- Added support for React 17 (resolves #241).
 
 ## [0.15.0] - 2021-05-04
 ### Added

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - glog (0.3.5)
   - React (0.57.5):
     - React/Core (= 0.57.5)
-  - react-native-heap (0.14.0):
+  - react-native-heap (0.16.0):
     - React
   - React/Core (0.57.5):
     - yoga (= 0.57.5.React)
@@ -18,7 +18,9 @@ PODS:
     - React/cxxreact
   - React/cxxreact (0.57.5):
     - boost-for-react-native (= 1.63.0)
+    - DoubleConversion
     - Folly (= 2016.10.31.00)
+    - glog
     - React/jschelpers
     - React/jsinspector
   - React/DevSupport (0.57.5):
@@ -102,14 +104,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
+  DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  React: 01aa04500b2957c2767e1dff9fe12e09444a467c
-  react-native-heap: c9924c2f98e9c48e6a8ce86c0a114c896900aec2
+  glog: e8acf0ebbf99759d3ff18c86c292a5898282dcde
+  React: 6bf0c347fee354f01a5495e957eab059a9d8b9b7
+  react-native-heap: c405c239fcc85500b836088c911765ca9cc0f38b
   RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
   yoga: a5c0ba30ebe82c13612b4c9301ad29708b8978dc
 
 PODFILE CHECKSUM: 94963ca9da08a6f38a9019eb8da64ec0f890b712
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.1

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "../preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.15.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.16.0.tgz",
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",

--- a/examples/TestDriverRN063/ios/Podfile.lock
+++ b/examples/TestDriverRN063/ios/Podfile.lock
@@ -236,10 +236,10 @@ PODS:
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
-  - react-native-heap (0.14.0):
+  - react-native-heap (0.16.0):
     - React
-  - react-native-safe-area-context (3.1.1):
-    - React
+  - react-native-safe-area-context (3.1.9):
+    - React-Core
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
   - React-RCTAnimation (0.63.2):
@@ -300,14 +300,14 @@ PODS:
     - React-Core (= 0.63.2)
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
-  - RNCMaskedView (0.1.10):
+  - RNCMaskedView (0.1.11):
     - React
-  - RNGestureHandler (1.7.0):
-    - React
-  - RNReanimated (1.10.1):
-    - React
-  - RNScreens (2.9.0):
-    - React
+  - RNGestureHandler (1.9.0):
+    - React-Core
+  - RNReanimated (1.13.2):
+    - React-Core
+  - RNScreens (2.17.1):
+    - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -475,8 +475,8 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-heap: c9924c2f98e9c48e6a8ce86c0a114c896900aec2
-  react-native-safe-area-context: 4c3249e4840225c61fcd215b136af0a737bccb79
+  react-native-heap: c405c239fcc85500b836088c911765ca9cc0f38b
+  react-native-safe-area-context: 86612d2c9a9e94e288319262d10b5f93f0b395f5
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13
@@ -487,13 +487,13 @@ SPEC CHECKSUMS:
   React-RCTText: 1b6773e776e4b33f90468c20fe3b16ca3e224bb8
   React-RCTVibration: 4d2e726957f4087449739b595f107c0d4b6c2d2d
   ReactCommon: a0a1edbebcac5e91338371b72ffc66aa822792ce
-  RNCMaskedView: f5c7d14d6847b7b44853f7acb6284c1da30a3459
-  RNGestureHandler: b6b359bb800ae399a9c8b27032bdbf7c18f08a08
-  RNReanimated: c2bb7438b57a3d987bb2e4e6e4bca94787e30b02
-  RNScreens: c526239bbe0e957b988dacc8d75ac94ec9cb19da
+  RNCMaskedView: f127cd9652acfa31b91dcff613e07ba18b774db6
+  RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
+  RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
+  RNScreens: b6c9607e6fe47c1b6e2f1910d2acd46dd7ecea3a
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
 PODFILE CHECKSUM: d9ae445cfccd43e04be127c22bd5e3229fd862b4
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.1

--- a/examples/TestDriverRN063/package.json
+++ b/examples/TestDriverRN063/package.json
@@ -11,7 +11,7 @@
     "preinstall": "../preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.15.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.16.0.tgz",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
## Heap Customer Support

Thanks for using Heap's React Native SDK! If you're having any issues, please reach out to customer support at <support@heap.io>. For the best service, include "React Native" in the subject and your app id or customer email address in the body. Also, feel free to file a github issue or open a PR! If you do so, be sure to include a link in your request to customer support. Our engineering team checks for new PRs and github issues and tries to respond as soon as possible.

## Description
What does this PR add/fix/change?
- Add support for React 17

Is there anything reviewers should pay special attention to?
- No

Are there any breaking changes?
- No

## Test Plan
How were these changes tested?
- Manually, with a local iOS simulator and local Android emulator against Heap production

Were additional test cases added?
- No

Was there manual testing?
- Yes. See above.

## Checklist
- [x] ~~Detox~~ Manual tests pass (only Heap employees are able run these)
- [x] If this is a bugfix/feature, the changelog has been updated
