### PR TITLE
Attempt to fix sporadic babel transpile issues

### DIFF
--- a/instrumentor/src/index.js
+++ b/instrumentor/src/index.js
@@ -27,8 +27,6 @@ const buildHeapImport = template(`(
 )`);
 
 const buildInstrumentationHoc = template(`
-  const Heap = HEAP_IMPORT;
-
   const COMPONENT_ID = HOC_CALL_EXPRESSION;
 `);
 
@@ -330,22 +328,21 @@ const instrumentTouchableHoc = path => {
 
   const hocIdentifier = t.identifier('withHeapTouchableAutocapture');
 
-  const autotrackExpression = t.callExpression(
-    t.memberExpression(t.identifier('Heap'), hocIdentifier),
-    [equivalentExpression]
-  );
-
   const heapImport = buildHeapImport({
     HOC_IDENTIFIER: hocIdentifier,
   });
 
+  const autotrackExpression = t.callExpression(
+    t.memberExpression(heapImport.expression, hocIdentifier),
+    [equivalentExpression]
+  );
+
   const replacement = buildInstrumentationHoc({
     COMPONENT_ID: path.node.id,
-    HEAP_IMPORT: heapImport,
     HOC_CALL_EXPRESSION: autotrackExpression,
   });
 
-  path.replaceWithMultiple(replacement);
+  path.replaceWith(replacement);
 };
 
 const instrumentTextInputHoc = path => {
@@ -361,22 +358,21 @@ const instrumentTextInputHoc = path => {
 
   const hocIdentifier = t.identifier('withHeapTextInputAutocapture');
 
-  const autotrackExpression = t.callExpression(
-    t.memberExpression(t.identifier('Heap'), hocIdentifier),
-    [equivalentExpression]
-  );
-
   const heapImport = buildHeapImport({
     HOC_IDENTIFIER: hocIdentifier,
   });
 
+  const autotrackExpression = t.callExpression(
+    t.memberExpression(heapImport.expression, hocIdentifier),
+    [equivalentExpression]
+  );
+
   const replacement = buildInstrumentationHoc({
     COMPONENT_ID: path.node.id,
-    HEAP_IMPORT: heapImport,
     HOC_CALL_EXPRESSION: autotrackExpression,
   });
 
-  path.replaceWithMultiple(replacement);
+  path.replaceWith(replacement);
 };
 
 const instrumentPressableHoc = path => {

--- a/instrumentor/test/fixtures/is-functional-textinput/output.js
+++ b/instrumentor/test/fixtures/is-functional-textinput/output.js
@@ -1,6 +1,5 @@
-var Heap = require('@heap/react-native-heap').default || {
+var InternalTextInput = (require('@heap/react-native-heap').default || {
   withHeapTextInputAutocapture: function withHeapTextInputAutocapture(Component) {
     return Component;
   }
-};
-var InternalTextInput = Heap.withHeapTextInputAutocapture(function InternalTextInput(props) {});
+}).withHeapTextInputAutocapture(function InternalTextInput(props) {});

--- a/instrumentor/test/fixtures/is-touchable-0-62/output.js
+++ b/instrumentor/test/fixtures/is-touchable-0-62/output.js
@@ -8,12 +8,11 @@ var _getPrototypeOf2 = _interopRequireDefault(require("@babel/runtime/helpers/ge
 
 var _inherits2 = _interopRequireDefault(require("@babel/runtime/helpers/inherits"));
 
-var Heap = require('@heap/react-native-heap').default || {
+var TouchableOpacity = (require('@heap/react-native-heap').default || {
   withHeapTouchableAutocapture: function withHeapTouchableAutocapture(Component) {
     return Component;
   }
-};
-var TouchableOpacity = Heap.withHeapTouchableAutocapture(function (_React$Component) {
+}).withHeapTouchableAutocapture(function (_React$Component) {
   (0, _inherits2.default)(TouchableOpacity, _React$Component);
 
   function TouchableOpacity() {


### PR DESCRIPTION
This is _potentially_ a fix for the `Cannot read property 'end' of null` issues we've been seeing, which could end up being a fix for the `assembleRelease` issue.

I'm not 100% confident this works because of our test suite, but I poked around the app manually and this seems to fix the problem for HOC instrumentation. Here's a quick overview of the steps I took here:

- I commented out instrumentation functions in `instrumentor/index.js` one by one to determine the smallest set of instrumentation types that causes the issue. This turned out to be `instrumentTextInputHoc` and `instrumentTouchableHoc`.
- Each of these functions ends with a call to `replaceWithMultiple`. From the [handbook](https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md#replacing-a-node-with-multiple-nodes):
  > Note: When replacing an expression with multiple nodes, they must be statements. This is because Babel uses heuristics extensively when replacing nodes which means that you can do some pretty crazy transformations that would be extremely verbose otherwise.
- Our replacement consists of two statements, but it's possible we're running afoul of one of these heuristics, so I replaced `replaceWithMultiple` with `replaceWith`, condensing the replacement into a single statement.
- This now works, and the build error doesn't show up anymore.

---

I was able to reproduce this consistently on the 0.63 TestDriver app against Xcode 12.5, but only if I cleared the transform cache with: `npm start -- --reset-cache`
