### PR TITLE
[HEAP-23436] Bump version to 0.17.0-alpha1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ __BEGIN_UNRELEASED__
 ### Security
 __END_UNRELEASED__
 
+## [0.17.0-alpha1] - 2021-06-09
+### Fixed
+- Fixed sporadic Babel instrumentation (`Cannot read property 'end' of null`) issues
+
 ## [0.16.0] - 2021-06-01
 ### Added
 - Added support for React 17 (resolves #241).

--- a/examples/TestDriver/ios/Podfile.lock
+++ b/examples/TestDriver/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - glog (0.3.5)
   - React (0.57.5):
     - React/Core (= 0.57.5)
-  - react-native-heap (0.16.0):
+  - react-native-heap (0.17.0-alpha1):
     - React
   - React/Core (0.57.5):
     - yoga (= 0.57.5.React)
@@ -18,9 +18,7 @@ PODS:
     - React/cxxreact
   - React/cxxreact (0.57.5):
     - boost-for-react-native (= 1.63.0)
-    - DoubleConversion
     - Folly (= 2016.10.31.00)
-    - glog
     - React/jschelpers
     - React/jsinspector
   - React/DevSupport (0.57.5):
@@ -107,8 +105,8 @@ SPEC CHECKSUMS:
   DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
   glog: e8acf0ebbf99759d3ff18c86c292a5898282dcde
-  React: 6bf0c347fee354f01a5495e957eab059a9d8b9b7
-  react-native-heap: c405c239fcc85500b836088c911765ca9cc0f38b
+  React: 01aa04500b2957c2767e1dff9fe12e09444a467c
+  react-native-heap: 047ed5ad07642fe678e0c97a859088c2ed6d4a75
   RNGestureHandler: 5329a942fce3d41c68b84c2c2276ce06a696d8b0
   yoga: a5c0ba30ebe82c13612b4c9301ad29708b8978dc
 

--- a/examples/TestDriver/package.json
+++ b/examples/TestDriver/package.json
@@ -8,7 +8,7 @@
     "preinstall": "../preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.16.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.17.0-alpha1.tgz",
     "native-base": "^2.12.1",
     "react": "16.6.1",
     "react-native": "0.57.5",

--- a/examples/TestDriverRN063/ios/Podfile.lock
+++ b/examples/TestDriverRN063/ios/Podfile.lock
@@ -236,9 +236,9 @@ PODS:
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
-  - react-native-heap (0.16.0):
+  - react-native-heap (0.17.0-alpha1):
     - React
-  - react-native-safe-area-context (3.1.9):
+  - react-native-safe-area-context (3.2.0):
     - React-Core
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
@@ -302,11 +302,11 @@ PODS:
     - React-jsi (= 0.63.2)
   - RNCMaskedView (0.1.11):
     - React
-  - RNGestureHandler (1.9.0):
+  - RNGestureHandler (1.10.3):
     - React-Core
-  - RNReanimated (1.13.2):
+  - RNReanimated (1.13.3):
     - React-Core
-  - RNScreens (2.17.1):
+  - RNScreens (2.18.1):
     - React-Core
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
@@ -475,8 +475,8 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-heap: c405c239fcc85500b836088c911765ca9cc0f38b
-  react-native-safe-area-context: 86612d2c9a9e94e288319262d10b5f93f0b395f5
+  react-native-heap: 047ed5ad07642fe678e0c97a859088c2ed6d4a75
+  react-native-safe-area-context: e471852c5ed67eea4b10c5d9d43c1cebae3b231d
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13
@@ -488,9 +488,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4d2e726957f4087449739b595f107c0d4b6c2d2d
   ReactCommon: a0a1edbebcac5e91338371b72ffc66aa822792ce
   RNCMaskedView: f127cd9652acfa31b91dcff613e07ba18b774db6
-  RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
-  RNReanimated: e03f7425cb7a38dcf1b644d680d1bfc91c3337ad
-  RNScreens: b6c9607e6fe47c1b6e2f1910d2acd46dd7ecea3a
+  RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
+  RNReanimated: 514a11da3a2bcc6c3dfd9de32b38e2b9bf101926
+  RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/examples/TestDriverRN063/package.json
+++ b/examples/TestDriverRN063/package.json
@@ -11,7 +11,7 @@
     "preinstall": "../preinstall_pack_lib.sh"
   },
   "dependencies": {
-    "@heap/react-native-heap": "heap-react-native-heap-0.16.0.tgz",
+    "@heap/react-native-heap": "heap-react-native-heap-0.17.0-alpha1.tgz",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.16.0",
+  "version": "0.17.0-alpha1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.16.0",
+  "version": "0.17.0-alpha1",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
## Description
- This alpha release just contains https://github.com/heap/react-native-heap/pull/256 at this point
- Release guide: https://heapinc.atlassian.net/wiki/spaces/ENG/pages/16222507/Publishing+react-native-heap+to+npm

## Test Plan
This change was manually tested against 0.63 but no automated testing has been applied

## Checklist
- [x] ~Detox tests pass (only Heap employees are able run these)~
- [x] If this is a bugfix/feature, the changelog has been updated
