### PR TITLE
Declare HeapIgnore and HeapIgnoreTargetText in `index.d.ts` instead of trying to import from JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+- Improve the types declared for `HeapIgnore` and `HeapIgnoreTargetText` so that
+  `tsc` does not complain that it cannot find the modules.
 ### Security
 __END_UNRELEASED__
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,5 @@
 import * as React from 'react';
 
-import { HeapIgnore, HeapIgnoreTargetText } from './js/autotrack/heapIgnore';
-
 /**
  * `setAppId` Initializes Heap tracking and sets the app ID where you'll be sending data. It can be used to switch
  * between projects or between your production and development environments.
@@ -136,7 +134,8 @@ export class Ignore extends React.Component {}
  */
 export const IgnoreTargetText: React.SFC;
 
-export { HeapIgnore, HeapIgnoreTargetText };
+export class HeapIgnore extends React.Component {}
+export class HeapIgnoreTargetText extends React.Component {}
 
 /**
  * The following functions are not available via the iOS and Android API.


### PR DESCRIPTION
## Description
> What does this PR add/fix/change?

In our Typescript app, we were running into an issue when using Heap - it wasn't able to find `HeapIgnore` and `HeapIgnoreTargetText`. 

```
node_modules/@heap/react-native-heap/index.d.ts:3:50 - error TS2307: Cannot find module './js/autotrack/heapIgnore' or its corresponding type declarations.

3 import { HeapIgnore, HeapIgnoreTargetText } from './js/autotrack/heapIgnore';
                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

We tried to patch `./js/autotrack/heapIgnore` to `./dist/autotrack/heapIgnore` (since it's present in `node_modules`), but a different error occurs:

```
node_modules/@heap/react-native-heap/index.d.ts:3:50 - error TS7016: Could not find a declaration file for module './dist/autotrack/heapIgnore'. '/Users/alockha/Projects/Datasite-Mobile/node_modules/@heap/react-native-heap/dist/autotrack/heapIgnore.js' implicitly has an 'any' type.

3 import { HeapIgnore, HeapIgnoreTargetText } from './dist/autotrack/heapIgnore';
                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```

To resolve this, this PR instead does not try to import those two components, and instead declares them directly in `index.d.ts`, similar to what is done there already for the `Ignore` component.

> Is there anything reviewers should pay special attention to?

I wasn't sure if I should be declaring any props - please let me know and I can improve the types.

> Are there any breaking changes?

There are no breaking changes.

## Test Plan
> How were these changes tested?

I applied these changes to my local project with `patch-package` and verified that `tsc` succeeded, as well as ensured that any usages of `HeapIgnore` were typed correctly.

> Were additional test cases added?

No, I didn't see any TS-specific tests in place. Please let me know and I can add some.

> Was there manual testing?

Yes, I manually tested these changes in my own project.

## Checklist
- [ ] Detox tests pass (only Heap employees are able run these)
- [x] If this is a bugfix/feature, the changelog has been updated
