### PR TITLE
Add a new HOC for autocapturing components that have onFocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+- Added `withHeapFocusableAutocapture` to support `onFocus` driven components
+  via HOC instrumentation
+- Added type declarations for HOC instrumentation for `Touchable` and `Pressable`
 ### Changed
 ### Deprecated
 ### Removed

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { GestureResponderEvent, NativeSyntheticEvent, TargetedEvent } from 'react-native';
 
 import { HeapIgnore, HeapIgnoreTargetText } from './js/autotrack/heapIgnore';
 
@@ -117,6 +118,42 @@ export function resetIdentity(): void;
  * Returns a promise that resolves to the stringified version of the numeric user ID associated with user.
  */
 export function getUserId(): Promise<string>;
+
+/**
+ * Returns an HOC of a component that tracks touches, i.e. calls to `onPress` or
+ * `onLongPress`
+ * 
+ * @param TouchableComponent the component to autocapture touches for
+ */
+ export function withHeapTouchableAutocapture<
+  P extends {
+    onPress?: (e: GestureResponderEvent) => void;
+    onLongPress?: (e: GestureResponderEvent) => void;
+  }
+>(TouchableComponent: React.ComponentType<P>): React.ComponentType<P>;
+export function getUserId(): Promise<string>;
+
+/**
+ * Returns an HOC of a component that tracks presses, i.e. calls to `onPress` or
+ * `onLongPress`
+ * 
+ * @param PressableComponent the component to autocapture presses for
+ */
+ export function withHeapPressableAutocapture<
+  P extends {
+    onPress?: (e: GestureResponderEvent) => void;
+    onLongPress?: (e: GestureResponderEvent) => void;
+  }
+>(PressableComponent: React.ComponentType<P>): React.ComponentType<P>;
+
+/**
+ * Returns an HOC of a component that tracks focuses, i.e. calls to `onFocus`
+ * 
+ * @param FocusableComponent the component to autocapture focuses for
+ */
+ export function withHeapFocusableAutocapture<
+ P extends { onFocus?: (e: NativeSyntheticEvent<TargetedEvent>) => void }
+>(FocusableComponent: React.ComponentType<P>): React.ComponentType<P>;
 
 /**
  * Returns an HOC of a component with specific HeapIgnore properties.

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -12,6 +12,7 @@ import {
   withHeapTouchableAutocapture,
 } from './autotrack/touchables';
 import { withHeapPressableAutocapture } from './autotrack/pressable';
+import { withHeapFocusableAutocapture } from './autotrack/focusable';
 import { autotrackSwitchChange } from './autotrack/switches';
 import { autotrackScrollView } from './autotrack/scrollViews';
 import {
@@ -90,6 +91,7 @@ export default {
   autotrackPress: bailOnError(autotrackPress(autocaptureTrack)),
   withHeapTouchableAutocapture: withHeapTouchableAutocapture(autocaptureTrack),
   withHeapPressableAutocapture: withHeapPressableAutocapture(autocaptureTrack),
+  withHeapFocusableAutocapture: withHeapFocusableAutocapture(autocaptureTrack),
   autotrackSwitchChange: bailOnError(autotrackSwitchChange(autocaptureTrack)),
   autocaptureScrollView: bailOnError(autotrackScrollView(autocaptureTrack)),
   autocaptureTextInput: bailOnError(

--- a/js/autotrack/focusable.js
+++ b/js/autotrack/focusable.js
@@ -1,0 +1,50 @@
+import hoistNonReactStatic from 'hoist-non-react-statics';
+import * as React from 'react';
+import { bailOnError } from '../util/bailer';
+import { getComponentDisplayName } from '../util/hocUtil';
+import { getBaseComponentProps } from './common';
+
+export const withHeapFocusableAutocapture = track => FocusableComponent => {
+  class HeapFocusableAutocapture extends React.Component {
+    trackEvent() {
+      const autotrackProps = getBaseComponentProps(this);
+
+      if (!autotrackProps) {
+        // We're not capturing this interaction.
+        return;
+      }
+
+      track('touch', autotrackProps);
+    }
+
+    render() {
+      const { heapForwardedRef, onFocus, ...rest } = this.props;
+
+      return (
+        <FocusableComponent
+          ref={heapForwardedRef}
+          onFocus={e => {
+            bailOnError(() => this.trackEvent(false))();
+
+            onFocus && onFocus(e);
+          }}
+          {...rest}
+        >
+          {this.props.children}
+        </FocusableComponent>
+      );
+    }
+  }
+
+  HeapFocusableAutocapture.displayName = `withHeapFocusableAutocapture(${getComponentDisplayName(
+    FocusableComponent
+  )})`;
+
+  const forwardRefHoc = React.forwardRef((props, ref) => {
+    return <HeapFocusableAutocapture {...props} heapForwardedRef={ref} />;
+  });
+
+  hoistNonReactStatic(forwardRefHoc, FocusableComponent);
+
+  return forwardRefHoc;
+};


### PR DESCRIPTION
## Description
> What does this PR add/fix/change?

Our project uses Pickers quite extensively, from https://github.com/react-native-picker/picker.

However, using these pickers has one limitation - unlike Touchables, etc. they are not instrumented with Heap for autocapture.

This means that we need to try and do it ourselves, either with custom events or another method. This is less than ideal, and is prone to errors.

This PR instead adds a new HOC that can be used to wrap the picker and wire it up with autocapture, like so:

```
import Heap from '@heap/react-native-heap';
import { Picker } from '@react-native-picker/picker';
const InstrumentedPicker = Heap.withHeapFocusableAutocapture(Picker);
```

Once it has been instrumented, whenever the picker opens (`onFocus`) we get a touch event auto captured in Heap. This then allows us to define our events directly in Heap with ease!

---

While working on this, we also had need to instrument some native components that, while not `Touchables` exactly, have `onPress` as a prop and behave in a similar way. To get this, we took a similar approach of using the HOC. This PR adds those HOCs to `index.d.ts` to ensure they can be used.

> Is there anything reviewers should pay special attention to?

I cloned a lot of the work in `withHeapFocusableAutocapture` from prior work - please let me know if it is correct.
I also tried my best to define the HOCs in TypeScript, but I may have missed something there too.

> Are there any breaking changes?

No, these are only additions.

## Test Plan
> How were these changes tested?

I applied these changes to my local project with `patch-package` and verified that:
- the instrumentation on the picker worked correctly
- all types passed type checking

> Were additional test cases added?

No, I did not see any test cases for the other HOCs, so I have not here. Please let me know what to cover and I will give it a try.

> Was there manual testing?

Yes, I tested manually in my project.

## Checklist
- [ ] Detox tests pass (only Heap employees are able run these)
- [x] If this is a bugfix/feature, the changelog has been updated
