### PR TITLE
iOS hotfix 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ __BEGIN_UNRELEASED__
 ### Security
 __END_UNRELEASED__
 
+## [0.17.1] - 2021-12-01
+
+### Fixed
+
+- Hotfix for misconfigured iOS event uploads.
+
 ## [0.17.0] - 2021-11-09
 
 ### Changed

--- a/integration-tests/drivers/TestDriver063/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver063/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-heap (0.17.0):
+  - react-native-heap (0.17.1):
     - Heap (~> 8.0)
     - React
   - react-native-safe-area-context (3.3.2):
@@ -381,7 +381,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-heap: ff34cc22b2a9e5bdcacc11073a8a448749f10d83
+  react-native-heap: e934f4ae2ec0c9bff47597ca9359fad268e8f789
   react-native-safe-area-context: 5cf05f49df9d17261e40e518481f2e334c6cd4b5
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b

--- a/integration-tests/drivers/TestDriver063/package-lock.json
+++ b/integration-tests/drivers/TestDriver063/package-lock.json
@@ -1024,8 +1024,8 @@
       }
     },
     "@heap/react-native-heap": {
-      "version": "file:../../heap-react-native-heap-0.17.0.tgz",
-      "integrity": "sha512-IL9GBy5xEbSOzb3eRPZkE1GdsdjNzItlJ39C1XOTlE3I9vRhP3Bcuh+/TS8WKAJHzgH61oBNmn/jJrC9H6fCcA==",
+      "version": "file:../../heap-react-native-heap-0.17.1.tgz",
+      "integrity": "sha512-uHoKSMMfZmS6THxdHSHS0m7FHSd2vARsh3jaGytXxT6F2dnJErjHrBquD6Z5Z6Q7IzF3Pzavkjp1d44Nsx5GQw==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@types/react-reconciler": "^0.26.4",

--- a/integration-tests/drivers/TestDriver063/package.json
+++ b/integration-tests/drivers/TestDriver063/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.17.0.tgz",
+    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.17.1.tgz",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",

--- a/ios/HeapSettings.bundle/generate_settings_common.rb
+++ b/ios/HeapSettings.bundle/generate_settings_common.rb
@@ -38,7 +38,7 @@ def get_enable_autocapture(selectedConfig, defaultConfig)
 end
 
 def get_capture_base_url(selectedConfig, defaultConfig)
-  return get_property('captureBaseUrl', false, selectedConfig, defaultConfig)
+  return get_property('captureBaseUrl', '', selectedConfig, defaultConfig)
 end
 
 def get_property(name, valueIfNil, selectedConfig, defaultConfig)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
## Description

This fixes a bug in ios/HeapSettings.bundle/generate_settings_common.rb, reported in #272, which broke iOS autocapture.

Ironically, this bug was introduced with testing code and not caught because automated testing wouldn't exercise the unset state.  Unit testing would be a good idea if we touch this again, generating a few different versions of the settings bundle and validating the `HeapOptions` that are outputted.

## Test Plan

This change was tested manually by adding the packed zip to a simple project and trying different permutations of heap.config.json.

## Checklist

- [ ] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated
