### PR TITLE
Fix iOS build script in directories with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+- Fixed iOS build in folders with spaces.
 - Fixed minSdkVersion build error on React Native 0.64+.
 ### Security
 __END_UNRELEASED__

--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.script_phase = {
     name: 'Generate `HeapSettings.plist`',
-    script: '$PODS_TARGET_SRCROOT/ios/HeapSettings.bundle/generate_settings.rb',
+    script: '"$PODS_TARGET_SRCROOT"/ios/HeapSettings.bundle/generate_settings.rb',
     execution_position: :after_compile,
     shell_path: '/bin/bash'
   }


### PR DESCRIPTION
## Description

The title says it all. The build script worked in `/Users/Brian/Project`, but not `/Users/Brian/My Project`.

## Test Plan

I used the integration-tests folder  and added a space in the name.  Running `npx react-native run-ios` failed without the fix and passed with it.

## Checklist
- [x] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated
