### PR TITLE
Added a script for overwriting Heap.xcframework locally

### DIFF
--- a/integration-tests/drivers/TestDriver063/ios/overwrite-heap.sh
+++ b/integration-tests/drivers/TestDriver063/ios/overwrite-heap.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+HEAP_DIR="../../../../../heap/tracker/ios"
+PODS_DIR="Pods"
+
+pushd "${HEAP_DIR}/scripts"
+HEAP_VERSION=$(./get_heap_version.rb)
+popd
+
+pushd "${HEAP_DIR}"
+bundle exec fastlane ios package_heap
+popd
+
+rm -rf "${PODS_DIR}/Heap/Heap.xcframework"
+cp -r "${HEAP_DIR}/build/heap-ios-${HEAP_VERSION}/Heap.xcframework" "${PODS_DIR}/Heap"


### PR DESCRIPTION
After experimenting with Cocoapods and relearning its deficiencies, I've come up with a simple script for testing local Heap changes in the TestDriver063 project.  The added script simply changes directories into the Heap project, builds the SDK and then copies it over `ios/Pods/Heap/Heap.xcframework`.  Crude but it gets the job done.


My _current_ process for testing Heap.xcframework changes with this is:

**Setup**

1. `cd integration-tests && ./test.sh drivers/TestDriver063 ios`
2. Let it run.
3. Edit `heap.config.json` as needed.

**Testing**

1. Make whatever changes I need in the **Heap project**.
2. `cd drivers/TestDriver063/ios`
3. `./overwrite-heap.sh` to install the changes.
4. `open TestDriver063.xcworkspace`, run the project in the simulator.
5. Rebuild and run the project.