### PR TITLE
Fix react internal detect

### DIFF
--- a/js/autotrack/common.ts
+++ b/js/autotrack/common.ts
@@ -101,7 +101,15 @@ const getComponentHierarchyTraversal: (
 };
 
 const getReactInternalFiber = (comp: Component) => {
-  return comp._reactInternals || comp._reactInternalFiber;
+  if (comp._reactInternals) {
+    return comp._reactInternals;
+  }
+
+  if (comp._reactInternalFiber) {
+    return comp._reactInternalFiber;
+  }
+
+  return null;
 };
 
 // Traverse up the hierarchy from the current component up to the root, and return an array of


### PR DESCRIPTION
RN 0.67.4 show: Pre-fiber React versions (React 16) are currently not supported by Heap autotrack. This fix detect react internal (react 17 and lower)
