### PR TITLE
0.19.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ __END_UNRELEASED__
 
 ### Added
 
+- Added support for Event Visualizer on iOS, with a pairing option in the React Native developer menu.
 - Added iOS-only option to enable Heap SDK debug logging in the iOS console, enabled by default on dev builds.
 - Disabled tracking of view controllers on iOS when `enableNativeTouchEventCapture` is off.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
+__END_UNRELEASED__
+
+## [0.19.0] - 2022-04-12
+
+### Added
 
 - Added iOS-only option to enable Heap SDK debug logging in the iOS console, enabled by default on dev builds.
 - Disabled tracking of view controllers on iOS when `enableNativeTouchEventCapture` is off.
@@ -16,12 +26,6 @@ __BEGIN_UNRELEASED__
 
 - Updated `Heap.setAppId` on iOS to turn off native touch capture on iOS.
 - Updated `Heap.setAppId` on iOS to enable logging on debug builds.
-
-### Deprecated
-### Removed
-### Fixed
-### Security
-__END_UNRELEASED__
 
 ## [0.18.0] - 2022-02-28
 

--- a/integration-tests/drivers/TestDriver063/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver063/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
   - React-jsinspector (0.63.4)
-  - react-native-heap (0.18.0):
+  - react-native-heap (0.19.0):
     - Heap (~> 8.2)
     - React
   - react-native-safe-area-context (3.3.2):
@@ -381,7 +381,7 @@ SPEC CHECKSUMS:
   React-jsi: a0418934cf48f25b485631deb27c64dc40fb4c31
   React-jsiexecutor: 93bd528844ad21dc07aab1c67cb10abae6df6949
   React-jsinspector: 58aef7155bc9a9683f5b60b35eccea8722a4f53a
-  react-native-heap: 0d0f082036bda12da84cef5bd833ce0e2be784c3
+  react-native-heap: b7ba358700d885cae251d578ef08a9b5798643e9
   react-native-safe-area-context: 5cf05f49df9d17261e40e518481f2e334c6cd4b5
   React-RCTActionSheet: 89a0ca9f4a06c1f93c26067af074ccdce0f40336
   React-RCTAnimation: 1bde3ecc0c104c55df246eda516e0deb03c4e49b

--- a/integration-tests/drivers/TestDriver063/package-lock.json
+++ b/integration-tests/drivers/TestDriver063/package-lock.json
@@ -1433,7 +1433,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.19.0.tgz",
-      "integrity": "sha512-wG8Fel3gLhyh9KVZ8YOKJjcDqCtgmdfresgmkM8me8fS0JGEmcRXz8E5636L//LNFgGdnjefiu5uTnY2E7X3ww==",
+      "integrity": "sha512-rZ5X9QPdHa57La7in0da+eUqOMhcUSPgKN1/LiRhdLPW4K22dk99SM5mKMiyKPhm8k/QfS7XMLtMutmYbP4BVQ==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@types/react-reconciler": "^0.26.4",

--- a/integration-tests/drivers/TestDriver063/package-lock.json
+++ b/integration-tests/drivers/TestDriver063/package-lock.json
@@ -1432,8 +1432,8 @@
       }
     },
     "@heap/react-native-heap": {
-      "version": "file:../../heap-react-native-heap-0.18.0.tgz",
-      "integrity": "sha512-dmLFWV7CIyJJ1+KVlHq+oKeZaFH8TWtMt+K5eajCmGpqM+jvUWNFNX7U09eQ1dejLHbzpaRM8VpCoGouDMhhhw==",
+      "version": "file:../../heap-react-native-heap-0.19.0.tgz",
+      "integrity": "sha512-/A6f7CPmfumbKNskmBXlPjwuknGXQZn5BRtUT3URFe1Fk+C46nktu4AM1jyMqHDqVwXTzfasYTtVDC3RC0tlUw==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@types/react-reconciler": "^0.26.4",

--- a/integration-tests/drivers/TestDriver063/package-lock.json
+++ b/integration-tests/drivers/TestDriver063/package-lock.json
@@ -1433,7 +1433,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.19.0.tgz",
-      "integrity": "sha512-/A6f7CPmfumbKNskmBXlPjwuknGXQZn5BRtUT3URFe1Fk+C46nktu4AM1jyMqHDqVwXTzfasYTtVDC3RC0tlUw==",
+      "integrity": "sha512-wG8Fel3gLhyh9KVZ8YOKJjcDqCtgmdfresgmkM8me8fS0JGEmcRXz8E5636L//LNFgGdnjefiu5uTnY2E7X3ww==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@types/react-reconciler": "^0.26.4",

--- a/integration-tests/drivers/TestDriver063/package.json
+++ b/integration-tests/drivers/TestDriver063/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.18.0.tgz",
+    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.19.0.tgz",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",

--- a/integration-tests/drivers/TestDriver066/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver066/ios/Podfile.lock
@@ -273,7 +273,7 @@ PODS:
   - React-jsinspector (0.66.1)
   - React-logger (0.66.1):
     - glog
-  - react-native-heap (0.18.0):
+  - react-native-heap (0.19.0):
     - Heap (~> 8.2)
     - React
   - react-native-safe-area-context (3.3.2):
@@ -535,7 +535,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: db2f6e22a534d466fc0e34e622df47d9d20bab2f
   React-jsinspector: 8c0517dee5e8c70cd6c3066f20213ff7ce54f176
   React-logger: bfddd3418dc1d45b77b822958f3e31422e2c179b
-  react-native-heap: 0d0f082036bda12da84cef5bd833ce0e2be784c3
+  react-native-heap: b7ba358700d885cae251d578ef08a9b5798643e9
   react-native-safe-area-context: 5cf05f49df9d17261e40e518481f2e334c6cd4b5
   React-perflogger: fcac6090a80e3d967791b4c7f1b1a017f9d4a398
   React-RCTActionSheet: caf5913d9f9e605f5467206cf9d1caa6d47d7ad6

--- a/integration-tests/drivers/TestDriver066/package-lock.json
+++ b/integration-tests/drivers/TestDriver066/package-lock.json
@@ -1456,7 +1456,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.19.0.tgz",
-      "integrity": "sha512-wG8Fel3gLhyh9KVZ8YOKJjcDqCtgmdfresgmkM8me8fS0JGEmcRXz8E5636L//LNFgGdnjefiu5uTnY2E7X3ww==",
+      "integrity": "sha512-rZ5X9QPdHa57La7in0da+eUqOMhcUSPgKN1/LiRhdLPW4K22dk99SM5mKMiyKPhm8k/QfS7XMLtMutmYbP4BVQ==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@types/react-reconciler": "^0.26.4",

--- a/integration-tests/drivers/TestDriver066/package-lock.json
+++ b/integration-tests/drivers/TestDriver066/package-lock.json
@@ -1456,7 +1456,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.19.0.tgz",
-      "integrity": "sha512-/A6f7CPmfumbKNskmBXlPjwuknGXQZn5BRtUT3URFe1Fk+C46nktu4AM1jyMqHDqVwXTzfasYTtVDC3RC0tlUw==",
+      "integrity": "sha512-wG8Fel3gLhyh9KVZ8YOKJjcDqCtgmdfresgmkM8me8fS0JGEmcRXz8E5636L//LNFgGdnjefiu5uTnY2E7X3ww==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@types/react-reconciler": "^0.26.4",

--- a/integration-tests/drivers/TestDriver066/package-lock.json
+++ b/integration-tests/drivers/TestDriver066/package-lock.json
@@ -1455,8 +1455,8 @@
       }
     },
     "@heap/react-native-heap": {
-      "version": "file:../../heap-react-native-heap-0.18.0.tgz",
-      "integrity": "sha512-dmLFWV7CIyJJ1+KVlHq+oKeZaFH8TWtMt+K5eajCmGpqM+jvUWNFNX7U09eQ1dejLHbzpaRM8VpCoGouDMhhhw==",
+      "version": "file:../../heap-react-native-heap-0.19.0.tgz",
+      "integrity": "sha512-/A6f7CPmfumbKNskmBXlPjwuknGXQZn5BRtUT3URFe1Fk+C46nktu4AM1jyMqHDqVwXTzfasYTtVDC3RC0tlUw==",
       "requires": {
         "@babel/core": "^7.16.0",
         "@types/react-reconciler": "^0.26.4",

--- a/integration-tests/drivers/TestDriver066/package.json
+++ b/integration-tests/drivers/TestDriver066/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.18.0.tgz",
+    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.19.0.tgz",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.17.1",
+  "version": "0.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
### Added

- Added support for Event Visualizer on iOS, with a pairing option in the React Native developer menu.
- Added iOS-only option to enable Heap SDK debug logging in the iOS console, enabled by default on dev builds.
- Disabled tracking of view controllers on iOS when `enableNativeTouchEventCapture` is off.

### Changed

- Updated `Heap.setAppId` on iOS to turn off native touch capture on iOS.
- Updated `Heap.setAppId` on iOS to enable logging on debug builds.

## Checklist
- [x] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated
