### PR TITLE
Be less prescriptive about NavigationContainer typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed type definition for `withReactNavigationAutotrack` on React Navigation 6.
+
 ### Security
 __END_UNRELEASED__
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,7 +121,7 @@ export function getUserId(): Promise<string>;
  * 
  * @param NavigationContainer The navigation container to track.
  */
-export function withReactNavigationAutotrack<P>(NavigationContainer: React.ForwardRefExoticComponent<P>): React.ForwardRefExoticComponent<P>;
+export function withReactNavigationAutotrack<P, C = React.JSXElementConstructor<P>>(NavigationContainer: C): C;
 
 /**
  * Properties to allow or ignore in withHeapIgnore.  All options default to false.


### PR DESCRIPTION
Fixes #277.

The type definition was overly prescriptive and produced a type error on React Native 6.  This is just something that creates an element.

## Checklist
- [x] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated
