### PR TITLE
[HEAP-28313] implement getSessionId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ __BEGIN_UNRELEASED__
 ### Security
 __END_UNRELEASED__
 
+## [0.21.0] - 2022-05-17
+
+### Added
+- Added `getSessionId()` method for fetching the current Heap Session ID from the underlying native SDK.
+
 ## [0.20.0] - 2022-04-28
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 __BEGIN_UNRELEASED__
 ## [Unreleased]
 ### Added
+- Added `getSessionId()` method for fetching the current Heap Session ID from the underlying native SDK.
+
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
 ### Security
 __END_UNRELEASED__
-
-## [0.21.0] - 2022-05-17
-
-### Added
-- Added `getSessionId()` method for fetching the current Heap Session ID from the underlying native SDK.
 
 ## [0.20.0] - 2022-04-28
 

--- a/__mocks__/react-native.js
+++ b/__mocks__/react-native.js
@@ -6,6 +6,7 @@ reactNative.NativeModules = {
     autocaptureEvent: jest.fn(),
     setAppId: jest.fn(),
     getUserId: jest.fn(),
+    getSessionId: jest.fn(),
     identify: jest.fn(),
     resetIdentity: jest.fn(),
     addUserProperties: jest.fn(),

--- a/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
+++ b/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
@@ -47,6 +47,9 @@ public class RNHeapLibraryModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
+  public void getSessionId(Promise promise) { promise.resolve(Heap.getSessionId()); }
+
+  @ReactMethod
   public void resetIdentity() {
     Heap.resetIdentity();
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -117,6 +117,12 @@ export function resetIdentity(): void;
 export function getUserId(): Promise<string>;
 
 /**
+ * Returns a promise that resolves to the stringified version of the numeric session ID associated with user's current session.
+ * If called before Heap is initialized it will return a promise that resolves to null.
+ */
+export function getSessionId(): Promise<string|null>;
+
+/**
  * Returns an HOC of a navigation container that autotracks pageviews on navigation change.
  * 
  * @param NavigationContainer The navigation container to track.

--- a/integration-tests/src/screens/PropertiesScreen.tsx
+++ b/integration-tests/src/screens/PropertiesScreen.tsx
@@ -28,6 +28,18 @@ export const PropertiesScreen = ({navigation}) => {
         title="Clear Event Properties"
         onPress={() => Heap.clearEventProperties()}
       />
+      <Button
+        title="Log getUserId"
+        onPress={async () =>
+          Heap.track('getUserId', {value: await Heap.getUserId()})
+        }
+      />
+      <Button
+        title="Log getSessionId"
+        onPress={async () =>
+          Heap.track('getSessionId', {value: await Heap.getSessionId()})
+        }
+      />
       <Button title="Back" onPress={() => navigation.goBack()} />
     </ScrollView>
   );

--- a/integration-tests/tests/heap_properties.e2e.js
+++ b/integration-tests/tests/heap_properties.e2e.js
@@ -5,7 +5,7 @@ import assert from 'assert';
 import {isAndroid, standardSetup, tapButton} from './util/util';
 import {getPropertyValue} from './util/types';
 
-describe('Properties', () => {
+describe('Heap Static Properties', () => {
   let tools = standardSetup(async () => {
     await tapButton('Properties');
   });

--- a/integration-tests/tests/heap_properties.e2e.js
+++ b/integration-tests/tests/heap_properties.e2e.js
@@ -1,0 +1,66 @@
+/* global describe */
+/* global it */
+/* global beforeEach */
+import assert from 'assert';
+import {isAndroid, standardSetup, tapButton} from './util/util';
+import {getPropertyValue} from './util/types';
+
+describe('Properties', () => {
+  let tools = standardSetup(async () => {
+    await tapButton('Properties');
+  });
+
+  describe('getUserId', () => {
+    it('should match user.id', async () => {
+      await tapButton('Log getUserId');
+
+      const message = await tools.server.expectSourceCustomEventWithProperties(
+        'getUserId',
+      );
+
+      const userIdFromPayload = isAndroid()
+        ? message.user?.id?.value
+        : message.user?.id;
+
+      assert.notEqual(
+        userIdFromPayload,
+        undefined,
+        'PRECONDITION: Unexpected issue reading user.id',
+      );
+
+      assert.equal(
+        userIdFromPayload,
+        getPropertyValue(
+          'value',
+          message.event.sourceCustomEvent.customProperties,
+        ),
+      );
+    });
+  });
+
+  describe('getSessionId', () => {
+    it('should match sessionInfo.id', async () => {
+      await tapButton('Log getSessionId');
+
+      const message = await tools.server.expectSourceCustomEventWithProperties(
+        'getSessionId',
+      );
+
+      const sessionIdFromPayload = message.sessionInfo?.id;
+
+      assert.notEqual(
+        sessionIdFromPayload,
+        undefined,
+        'PRECONDITION: Unexpected issue reading sessionInfo.id',
+      );
+
+      assert.equal(
+        sessionIdFromPayload,
+        getPropertyValue(
+          'value',
+          message.event.sourceCustomEvent.customProperties,
+        ),
+      );
+    });
+  });
+});

--- a/integration-tests/tests/util/server.ts
+++ b/integration-tests/tests/util/server.ts
@@ -12,6 +12,8 @@ import {
   CaptureSourceEvent,
   getPropertyValue,
   matcherForSourceEventWithProperties,
+  matcherForSourceCustomEventWithProperties,
+  CaptureSourceCustomEvent,
 } from './types';
 import {isAndroid} from './util';
 import assert from 'assert';
@@ -294,6 +296,27 @@ export class CaptureServer extends EventEmitter {
         )}`,
     );
     return <CaptureMessage<CaptureSourceEvent>>result;
+  }
+
+  async expectSourceCustomEventWithProperties(
+    expectedType: string,
+    expectedSourceProperties: {[key: string]: string | boolean} = {},
+    expectedCustomProperties: {[key: string]: string | boolean} = {},
+  ): Promise<CaptureMessage<CaptureSourceCustomEvent>> {
+    const result = await this.waitForMatchingMessage(
+      matcherForSourceCustomEventWithProperties(
+        expectedType,
+        expectedSourceProperties,
+        expectedCustomProperties,
+      ),
+      () =>
+        `timeout waiting for ${expectedType} event with ${JSON.stringify(
+          expectedSourceProperties,
+          undefined,
+          2,
+        )} and ${JSON.stringify(expectedCustomProperties, undefined, 2)}`,
+    );
+    return <CaptureMessage<CaptureSourceCustomEvent>>result;
   }
 
   assertNoExistingSourceEventWithProperties(

--- a/integration-tests/tests/util/types.ts
+++ b/integration-tests/tests/util/types.ts
@@ -6,6 +6,10 @@ export interface CaptureSourceEvent extends CaptureEvent {
   sourceEvent: CaptureSourceEventPayload;
 }
 
+export interface CaptureSourceCustomEvent extends CaptureEvent {
+  sourceCustomEvent: CaptureSourceCustomEventPayload;
+}
+
 export interface BoolProperty {
   bool: boolean;
 }
@@ -19,6 +23,11 @@ export interface CaptureSourceEventPayload {
   name?: string;
   sourceProperties: {[key: string]: BoolProperty | StringProperty};
   source: string;
+}
+
+export interface CaptureSourceCustomEventPayload
+  extends CaptureSourceEventPayload {
+  customProperties: {[key: string]: BoolProperty | StringProperty};
 }
 
 export interface CaptureMessage<T extends CaptureEvent> {
@@ -51,6 +60,12 @@ export function isSourceEvent(
   event: CaptureEvent,
 ): event is CaptureSourceEvent {
   return has(event, 'sourceEvent');
+}
+
+export function isSourceCustomEvent(
+  event: CaptureEvent,
+): event is CaptureSourceCustomEvent {
+  return has(event, 'sourceCustomEvent');
 }
 
 // This keeps getting formatted away. :(
@@ -98,6 +113,49 @@ export function matcherForSourceEventWithProperties(
 
     for (const [key, value] of Object.entries(expectedProperties)) {
       if (getPropertyValue(key, event.sourceEvent.sourceProperties) !== value) {
+        return false;
+      }
+    }
+
+    return true;
+  };
+}
+
+export function matcherForSourceCustomEventWithProperties(
+  expectedType: string,
+  expectedSourceProperties: {[key: string]: string | boolean},
+  expectedCustomProperties: {[key: string]: string | boolean},
+): (
+  message: CaptureMessage<CaptureEvent>,
+) => message is CaptureMessage<CaptureSourceCustomEvent> {
+  return (message): message is CaptureMessage<CaptureSourceCustomEvent> => {
+    const event = message.event;
+
+    if (!isSourceCustomEvent(event)) {
+      return false;
+    }
+
+    if (
+      event.sourceCustomEvent.type !== expectedType &&
+      event.sourceCustomEvent.name !== expectedType
+    ) {
+      return false;
+    }
+
+    for (const [key, value] of Object.entries(expectedSourceProperties)) {
+      if (
+        getPropertyValue(key, event.sourceCustomEvent.sourceProperties) !==
+        value
+      ) {
+        return false;
+      }
+    }
+
+    for (const [key, value] of Object.entries(expectedCustomProperties)) {
+      if (
+        getPropertyValue(key, event.sourceCustomEvent.customProperties) !==
+        value
+      ) {
         return false;
       }
     }

--- a/ios/RNHeap.m
+++ b/ios/RNHeap.m
@@ -61,6 +61,11 @@ RCT_REMAP_METHOD(getUserId, getUserIdWithResolver:(RCTPromiseResolveBlock)resolv
     resolve(userId);
 }
 
+RCT_REMAP_METHOD(getSessionId, getSessionIdWithResolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    NSString *sessionId = [Heap sessionId];
+    resolve(sessionId);
+}
+
 RCT_EXPORT_METHOD(identify:(NSString *)identity) {
     [Heap identify:identity];
 }

--- a/js/Heap.js
+++ b/js/Heap.js
@@ -60,6 +60,7 @@ export default {
   // User Properties
   // Returns a promise that resolves to the Heap user ID.
   getUserId: bailOnError(() => RNHeap.getUserId()),
+  getSessionId: bailOnError(() => RNHeap.getSessionId()),
   identify: bailOnError(identity => RNHeap.identify(identity)),
   resetIdentity: bailOnError(() => RNHeap.resetIdentity()),
   addUserProperties: bailOnError(properties => {

--- a/js/__tests__/Heap.spec.js
+++ b/js/__tests__/Heap.spec.js
@@ -15,6 +15,7 @@ describe('The Heap object', () => {
   let mockTrack,
     mockSetAppId,
     mockGetUserId,
+    mockGetSessionId,
     mockIdentify,
     mockResetIdentity,
     mockAddUserProperties,
@@ -41,6 +42,9 @@ describe('The Heap object', () => {
 
     NativeModules.RNHeap.getUserId.mockReset();
     mockGetUserId = NativeModules.RNHeap.getUserId;
+
+    NativeModules.RNHeap.getSessionId.mockReset();
+    mockGetSessionId = NativeModules.RNHeap.getSessionId;
 
     NativeModules.RNHeap.identify.mockReset();
     mockIdentify = NativeModules.RNHeap.identify;
@@ -144,6 +148,12 @@ describe('The Heap object', () => {
       expect(userId).toBe('1234');
     });
 
+    it('getSessionId - handles the common case', async () => {
+      mockGetSessionId.mockReturnValue(Promise.resolve('5678'));
+      const sessionId = await Heap.getSessionId();
+      expect(sessionId).toBe('5678');
+    });
+
     it('identify - handles the common case', () => {
       Heap.identify('foo');
       expect(mockIdentify.mock.calls.length).toBe(1);
@@ -190,6 +200,11 @@ describe('The Heap object', () => {
     it('getUserId - prevents errors from bubbling up', () => {
       mockGetUserId.mockImplementation(throwFn);
       expect(() => Heap.getUserId()).not.toThrow();
+    });
+
+    it('getSessionId - prevents errors from bubbling up', () => {
+      mockGetSessionId.mockImplementation(throwFn);
+      expect(() => Heap.getSessionId()).not.toThrow();
     });
 
     it('identify - prevents errors from bubbling up', () => {


### PR DESCRIPTION
## Heap Customer Support

Thanks for using Heap's React Native SDK! If you're having any issues, please reach out to customer support at <support@heap.io>. For the best service, include "React Native" in the subject and your app id or customer email address in the body. Also, feel free to file a github issue or open a PR! If you do so, be sure to include a link in your request to customer support. Our engineering team checks for new PRs and github issues and tries to respond as soon as possible.

## Description
What does this PR add/fix/change?
adds `getSessionId` method to return the current session id.

Is there anything reviewers should pay special attention to?
tests - they only partially ran locally but the mock tests seemed fine. Also this is mostly a copy and paste of `getUserId` but the difference with `getSessionId` is that it can return `null` if called before initialization, which differs and I may have done something wrong there with types or the promise.

Are there any breaking changes?
shouldn't be

## Test Plan
How were these changes tested?
mocked tests in jest

Were additional test cases added?
yes
Was there manual testing?
no

## Checklist
- [ ] Detox tests pass
- [ ] If this is a bugfix/feature, the changelog has been updated
