### PR TITLE
chore: fix Log.w message that was causing issue with android builds

### DIFF
--- a/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
+++ b/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
@@ -83,7 +83,7 @@ public class RNHeapLibraryModule extends ReactContextBaseJavaModule {
         // The JS bridge will flatten maps and arrays in a uniform manner across both
         // platforms.
         // If we get them at this point, we shouldn't continue.
-        Log.w("Property objects must be flattened before being sent across the JS bridge. If you get this warning please inspect for non-flattenable objects being sent to Heap");
+        Log.w("RNHeapLibraryModule", "Property objects must be flattened before being sent across the JS bridge. If you get this warning please inspect for non-flattenable objects being sent to Heap");
       }
     }
     return stringMap;

--- a/integration-tests/drivers/TestDriver063/__tests__/App-test.js
+++ b/integration-tests/drivers/TestDriver063/__tests__/App-test.js
@@ -4,7 +4,7 @@
 
 import 'react-native';
 import React from 'react';
-import App from '../App';
+import App from '../../../src/App';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/integration-tests/drivers/TestDriver066/__tests__/App-test.js
+++ b/integration-tests/drivers/TestDriver066/__tests__/App-test.js
@@ -4,7 +4,7 @@
 
 import 'react-native';
 import React from 'react';
-import App from '../App';
+import App from '../../../src/App';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/integration-tests/drivers/TestDriver066/index.js
+++ b/integration-tests/drivers/TestDriver066/index.js
@@ -3,7 +3,7 @@
  */
 
 import {AppRegistry} from 'react-native';
-import App from './src/App';
+import App from '../../src/App';
 import {name as appName} from './app.json';
 
 AppRegistry.registerComponent(appName, () => App);

--- a/js/util/metadataPropUtil.ts
+++ b/js/util/metadataPropUtil.ts
@@ -2,7 +2,7 @@ import NavigationUtil from './navigationUtil';
 
 const { Platform } = require('react-native');
 
-const { version } = require('../../../package.json');
+const { version } = require('../../package.json');
 
 let reactNativeVersionString: String | null = null;
 


### PR DESCRIPTION
## Heap Customer Support

Thanks for using Heap's React Native SDK! If you're having any issues, please reach out to customer support at <support@heap.io>. For the best service, include "React Native" in the subject and your app id or customer email address in the body. Also, feel free to file a github issue or open a PR! If you do so, be sure to include a link in your request to customer support. Our engineering team checks for new PRs and github issues and tries to respond as soon as possible.

## Description
Small PR that fixes the Log warning that was added in previous version. Log.w needs a tag and a message string. Not passing the method cause the app not to build on Android
Also the integrations tests' imports for the App component was setup incorrectly. metadataPropUtil.ts under js/util also had the wrong import (Please feel free to let me know if i have the configs wrong. I can revert the last changes, as the target of this PR was only to fix the warning issue on Android)
 
## Test Plan
Same tests as it already had. Simply tested it on our current product to make sure it builds now and ran the repo's tests

## Checklist
- [ ] Detox tests pass
- [ ] If this is a bugfix/feature, the changelog has been updated
