### PR TITLE
migrate from jcenter to maven

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ def heapAppId(buildType) {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 
@@ -75,7 +75,6 @@ android {
 
 repositories {
     mavenCentral()
-    jcenter()
     google()
 }
 


### PR DESCRIPTION
## Heap Customer Support

Thanks for using Heap's React Native SDK! If you're having any issues, please reach out to customer support at <support@heap.io>. For the best service, include "React Native" in the subject and your app id or customer email address in the body. Also, feel free to file a github issue or open a PR! If you do so, be sure to include a link in your request to customer support. Our engineering team checks for new PRs and github issues and tries to respond as soon as possible.

## Description
What does this PR add/fix/change?
- Migrates the Android deps from `jcenter` to `mavenCentral` as `jcenter` has been deprecated

Is there anything reviewers should pay special attention to?
Are there any breaking changes?

## Test Plan
How were these changes tested?
Were additional test cases added?
Was there manual testing?

## Checklist
- [ ] Detox tests pass
- [ ] If this is a bugfix/feature, the changelog has been updated
