### PR TITLE
fix: added missing parameter to Log.w method in Map case

### DIFF
--- a/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
+++ b/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java
@@ -83,7 +83,7 @@ public class RNHeapLibraryModule extends ReactContextBaseJavaModule {
         // The JS bridge will flatten maps and arrays in a uniform manner across both
         // platforms.
         // If we get them at this point, we shouldn't continue.
-        Log.w("Property objects must be flattened before being sent across the JS bridge. If you get this warning please inspect for non-flattenable objects being sent to Heap");
+        Log.w("RNHeapLibraryModule", "Property objects must be flattened before being sent across the JS bridge. If you get this warning please inspect for non-flattenable objects being sent to Heap");
       }
     }
     return stringMap;


### PR DESCRIPTION
## Heap Customer Support

Thanks for using Heap's React Native SDK! If you're having any issues, please reach out to customer support at <support@heap.io>. For the best service, include "React Native" in the subject and your app id or customer email address in the body. Also, feel free to file a github issue or open a PR! If you do so, be sure to include a link in your request to customer support. Our engineering team checks for new PRs and github issues and tries to respond as soon as possible.

## Description
What does this PR add/fix/change?
Error when building Android due to missing parameter in Log.w method
`@heap/react-native-heap/android/src/main/java/com/heapanalytics/reactnative/RNHeapLibraryModule.java:86: error: no suitable method found for w(String)`

Is there anything reviewers should pay special attention to?
N/A
Are there any breaking changes?
No

## Test Plan
How were these changes tested?
Installing and using the library
Were additional test cases added?
No
Was there manual testing?
Yes

## Checklist
- [ ] Detox tests pass
- [ ] If this is a bugfix/feature, the changelog has been updated

Fixes #334 and #347
