### PR TITLE
Resolve install issue with ruby >= 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ __BEGIN_UNRELEASED__
 ### Deprecated
 ### Removed
 ### Fixed
+
+- Fixed pod install with ruby >= 3.1
+
 ### Security
 __END_UNRELEASED__
 

--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license = { type: "MIT" }
   s.author = package[:author]
   s.homepage = package[:homepage]
-  s.source = { git: package[:repository] }
+  s.source = { git: package[:repository][:url] }
   s.source_files = "ios/**/*.{h,m}"
   s.platform = :ios, "10.0"
 


### PR DESCRIPTION
## Description

Fixes https://github.com/heap/react-native-heap/issues/374

## Test Plan

Tested locally by running `bundle exec pod install` with ruby 3.2.1 and ruby 3.0.5

## Checklist

- [x] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated