### PR TITLE
[HEAP-46713] Release 0.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.4] - 2023-09-05
+
 ### Fixed
 
  - Fixed `<Switch>` change event capture on React Native 0.66 and later.
@@ -280,7 +282,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ability to use Heap's identity APIs from React Native code.
 - Instructions for install and use.
 
-[unreleased]: https://github.com/heap/react-native-heap/compare/0.22.3...HEAD
+[unreleased]: https://github.com/heap/react-native-heap/compare/0.22.4...HEAD
+[0.22.4]: https://github.com/heap/react-native-heap/compare/0.22.3...0.22.4
 [0.22.3]: https://github.com/heap/react-native-heap/compare/0.22.2...0.22.3
 [0.22.2]: https://github.com/heap/react-native-heap/compare/0.22.1...0.22.2
 [0.22.1]: https://github.com/heap/react-native-heap/compare/0.22.0...0.22.1

--- a/integration-tests/drivers/TestDriver063/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver063/ios/Podfile.lock
@@ -186,7 +186,7 @@ PODS:
     - React-cxxreact (= 0.63.5)
     - React-jsi (= 0.63.5)
   - React-jsinspector (0.63.5)
-  - react-native-heap (0.22.3):
+  - react-native-heap (0.22.4):
     - Heap (~> 9.0)
     - React
   - react-native-safe-area-context (3.3.2):
@@ -381,7 +381,7 @@ SPEC CHECKSUMS:
   React-jsi: 7d908b17758178b076a05a254523f1a4227b53d2
   React-jsiexecutor: e06a32e42affb2bd89e4c8369349b5fcf787710c
   React-jsinspector: fdbc08866b34ae8e1b788ea1cbd9f9d1ca2aa3d6
-  react-native-heap: da918ba329898d671d6c536d34772017e35b5afe
+  react-native-heap: f179319f2bff9c601dad23115ade6cee24f96e7d
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-RCTActionSheet: e911b99f0d6fa7711ffc2f62d236b12a32771835
   React-RCTAnimation: ad8b853170a059faf31d6add34f67d22391bbe01

--- a/integration-tests/drivers/TestDriver063/package-lock.json
+++ b/integration-tests/drivers/TestDriver063/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@heap/react-native-heap": "file:../../heap-react-native-heap-0.22.3.tgz",
+        "@heap/react-native-heap": "file:../../heap-react-native-heap-0.22.4.tgz",
         "@react-native-community/masked-view": "^0.1.10",
         "@react-navigation/bottom-tabs": "^5.7.3",
         "@react-navigation/native": "^5.7.2",
@@ -2403,9 +2403,9 @@
       }
     },
     "node_modules/@heap/react-native-heap": {
-      "version": "0.22.3",
-      "resolved": "file:../../heap-react-native-heap-0.22.3.tgz",
-      "integrity": "sha512-wOB2DDBhdctZS8KvNo0g7CG0A9bOkQ24/mRODH7t6UAeJz+YtwBQcD8Tzaf9ggHVulqvrECNHkNSPrjOPCK9rA==",
+      "version": "0.22.4",
+      "resolved": "file:../../heap-react-native-heap-0.22.4.tgz",
+      "integrity": "sha512-w2VWGkifa9FFZ/R+Bl+eBRz8q8FmhBd+V7/9rKIvqfkIN8XCT1jqvunSQL3sfqSAv2acZJcgcMaWJA6lSYi8WQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -24393,8 +24393,8 @@
       }
     },
     "@heap/react-native-heap": {
-      "version": "file:../../heap-react-native-heap-0.22.3.tgz",
-      "integrity": "sha512-wOB2DDBhdctZS8KvNo0g7CG0A9bOkQ24/mRODH7t6UAeJz+YtwBQcD8Tzaf9ggHVulqvrECNHkNSPrjOPCK9rA==",
+      "version": "file:../../heap-react-native-heap-0.22.4.tgz",
+      "integrity": "sha512-w2VWGkifa9FFZ/R+Bl+eBRz8q8FmhBd+V7/9rKIvqfkIN8XCT1jqvunSQL3sfqSAv2acZJcgcMaWJA6lSYi8WQ==",
       "requires": {
         "@babel/core": "^7.16.0",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/integration-tests/drivers/TestDriver063/package.json
+++ b/integration-tests/drivers/TestDriver063/package.json
@@ -11,7 +11,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.22.3.tgz",
+    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.22.4.tgz",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",

--- a/integration-tests/drivers/TestDriver066/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver066/ios/Podfile.lock
@@ -273,7 +273,7 @@ PODS:
   - React-jsinspector (0.66.5)
   - React-logger (0.66.5):
     - glog
-  - react-native-heap (0.22.3):
+  - react-native-heap (0.22.4):
     - Heap (~> 9.0)
     - React
   - react-native-safe-area-context (3.3.2):
@@ -535,7 +535,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 50a73168582868421112609d2fb155e607e34ec8
   React-jsinspector: 953260b8580780a6e81f2a6d319a8d42fd5028d8
   React-logger: fa4ff1e9c7e115648f7c5dafb7c20822ab4f7a7e
-  react-native-heap: 09f2b37f1ef8dd0a5b9cad25b9f9fb323d994a7f
+  react-native-heap: ad93c14f7c9ef03d676e68abe6a2d1f358228e3e
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-perflogger: 169fb34f60c5fd793b370002ee9c916eba9bc4ae
   React-RCTActionSheet: 2355539e02ad5cd4b1328682ab046487e1e1e920

--- a/integration-tests/drivers/TestDriver066/package-lock.json
+++ b/integration-tests/drivers/TestDriver066/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "@heap/react-native-heap": "file:../../heap-react-native-heap-0.22.3.tgz",
+        "@heap/react-native-heap": "file:../../heap-react-native-heap-0.22.4.tgz",
         "@react-native-community/masked-view": "^0.1.10",
         "@react-navigation/bottom-tabs": "^5.7.3",
         "@react-navigation/native": "^5.7.2",
@@ -2262,9 +2262,9 @@
       }
     },
     "node_modules/@heap/react-native-heap": {
-      "version": "0.22.3",
-      "resolved": "file:../../heap-react-native-heap-0.22.3.tgz",
-      "integrity": "sha512-wOB2DDBhdctZS8KvNo0g7CG0A9bOkQ24/mRODH7t6UAeJz+YtwBQcD8Tzaf9ggHVulqvrECNHkNSPrjOPCK9rA==",
+      "version": "0.22.4",
+      "resolved": "file:../../heap-react-native-heap-0.22.4.tgz",
+      "integrity": "sha512-w2VWGkifa9FFZ/R+Bl+eBRz8q8FmhBd+V7/9rKIvqfkIN8XCT1jqvunSQL3sfqSAv2acZJcgcMaWJA6lSYi8WQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -18783,8 +18783,8 @@
       }
     },
     "@heap/react-native-heap": {
-      "version": "file:../../heap-react-native-heap-0.22.3.tgz",
-      "integrity": "sha512-wOB2DDBhdctZS8KvNo0g7CG0A9bOkQ24/mRODH7t6UAeJz+YtwBQcD8Tzaf9ggHVulqvrECNHkNSPrjOPCK9rA==",
+      "version": "file:../../heap-react-native-heap-0.22.4.tgz",
+      "integrity": "sha512-w2VWGkifa9FFZ/R+Bl+eBRz8q8FmhBd+V7/9rKIvqfkIN8XCT1jqvunSQL3sfqSAv2acZJcgcMaWJA6lSYi8WQ==",
       "requires": {
         "@babel/core": "^7.16.0",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/integration-tests/drivers/TestDriver066/package.json
+++ b/integration-tests/drivers/TestDriver066/package.json
@@ -11,7 +11,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.22.3.tgz",
+    "@heap/react-native-heap": "file:../../heap-react-native-heap-0.22.4.tgz",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.7.3",
     "@react-navigation/native": "^5.7.2",

--- a/js/version.ts
+++ b/js/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.22.3";
+export const version = "0.22.4";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@heap/react-native-heap",
-      "version": "0.22.3",
+      "version": "0.22.4",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heap/react-native-heap",
-  "version": "0.22.3",
+  "version": "0.22.4",
   "description": "React Native event tracking with Heap.",
   "license": "MIT",
   "author": "Heap <http://www.heapanalytics.com>",


### PR DESCRIPTION
[HEAP-46713](https://heapinc.atlassian.net/browse/HEAP-46713)

### Fixed

  - Fixed `<Switch>` change event capture on React Native 0.66 and later.

## Checklist
- [x] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated


[HEAP-46713]: https://heapinc.atlassian.net/browse/HEAP-46713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ