### PR TITLE
[HEAP-48116] Update `<HeapIgnore>` to support React 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multiple times, preventing app refreshes when used within a
   re-evaluated function like `App` with `useEffect`.
 
+- The typescript definition for `<HeapIgnore/>` has been updated to support
+  React 18.
+
 ## [0.22.4] - 2023-09-05
 
 ### Fixed

--- a/index.d.ts
+++ b/index.d.ts
@@ -148,14 +148,21 @@ export interface HeapIgnoreProps {
 export function withHeapIgnore<P>(IgnoredComponent: React.JSXElementConstructor<P>, heapIgnoreConfig?: HeapIgnoreProps): React.JSXElementConstructor<P>;
 
 /**
+ * Properties to allow or ignore in HeapIgnore.  All options default to false.
+ */
+interface HeapIgnorePropsWithChildren extends HeapIgnoreProps {
+    children?: React.ReactNode | undefined;
+}
+
+/**
  * Component for ignoring all or parts of interactions with children of this component.
  */
-export class HeapIgnore extends React.Component<HeapIgnoreProps> {}
+export class HeapIgnore extends React.Component<HeapIgnorePropsWithChildren> {}
 
 /**
  * An alias for HeapIgnore.
  */
-export class Ignore extends React.Component<HeapIgnoreProps> {}
+export class Ignore extends React.Component<HeapIgnorePropsWithChildren> {}
 
 /**
  * Convenience component for ignoring 'target_text' on interactions with children of this component.


### PR DESCRIPTION
[HEAP-48116](https://heapinc.atlassian.net/browse/HEAP-48116)

## Description

As reported in #407, React 18 doesn't implicitly add a `children` parameter to components.  This resolve that issue without also accepting `children` in `withHeapIgnore`.

## Test Plan

Changes were tested by installing the new version in a sample app and checking autocomplete/errors.

## Checklist

- [x] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated

fixes #407


[HEAP-48116]: https://heapinc.atlassian.net/browse/HEAP-48116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ