### PR TITLE
[HEAP-48203] Produce a consistent Cocoapods checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multiple times, preventing app refreshes when used within a
   re-evaluated function like `App` with `useEffect`.
 
+- Podspec now produces a stable checksum in Podfile.lock across machines.
+
 ## [0.22.4] - 2023-09-05
 
 ### Fixed

--- a/integration-tests/drivers/TestDriver063/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver063/ios/Podfile.lock
@@ -381,7 +381,7 @@ SPEC CHECKSUMS:
   React-jsi: 7d908b17758178b076a05a254523f1a4227b53d2
   React-jsiexecutor: e06a32e42affb2bd89e4c8369349b5fcf787710c
   React-jsinspector: fdbc08866b34ae8e1b788ea1cbd9f9d1ca2aa3d6
-  react-native-heap: f179319f2bff9c601dad23115ade6cee24f96e7d
+  react-native-heap: 697d6c2de93a5019c4ed6df8641a0156aebcb594
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-RCTActionSheet: e911b99f0d6fa7711ffc2f62d236b12a32771835
   React-RCTAnimation: ad8b853170a059faf31d6add34f67d22391bbe01

--- a/integration-tests/drivers/TestDriver063/package-lock.json
+++ b/integration-tests/drivers/TestDriver063/package-lock.json
@@ -2405,7 +2405,7 @@
     "node_modules/@heap/react-native-heap": {
       "version": "0.22.4",
       "resolved": "file:../../heap-react-native-heap-0.22.4.tgz",
-      "integrity": "sha512-w2VWGkifa9FFZ/R+Bl+eBRz8q8FmhBd+V7/9rKIvqfkIN8XCT1jqvunSQL3sfqSAv2acZJcgcMaWJA6lSYi8WQ==",
+      "integrity": "sha512-p2hI3vumj6nmsmqKdoMyeBN8eBGJrBi3TIBbAW0HF2eqow1mYckQ5YRM85G1OLbz/BgJYmns8bnBlkMT68xsWA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -24394,7 +24394,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.22.4.tgz",
-      "integrity": "sha512-w2VWGkifa9FFZ/R+Bl+eBRz8q8FmhBd+V7/9rKIvqfkIN8XCT1jqvunSQL3sfqSAv2acZJcgcMaWJA6lSYi8WQ==",
+      "integrity": "sha512-p2hI3vumj6nmsmqKdoMyeBN8eBGJrBi3TIBbAW0HF2eqow1mYckQ5YRM85G1OLbz/BgJYmns8bnBlkMT68xsWA==",
       "requires": {
         "@babel/core": "^7.16.0",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/integration-tests/drivers/TestDriver066/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver066/ios/Podfile.lock
@@ -535,7 +535,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 50a73168582868421112609d2fb155e607e34ec8
   React-jsinspector: 953260b8580780a6e81f2a6d319a8d42fd5028d8
   React-logger: fa4ff1e9c7e115648f7c5dafb7c20822ab4f7a7e
-  react-native-heap: ad93c14f7c9ef03d676e68abe6a2d1f358228e3e
+  react-native-heap: 697d6c2de93a5019c4ed6df8641a0156aebcb594
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-perflogger: 169fb34f60c5fd793b370002ee9c916eba9bc4ae
   React-RCTActionSheet: 2355539e02ad5cd4b1328682ab046487e1e1e920

--- a/integration-tests/drivers/TestDriver066/package-lock.json
+++ b/integration-tests/drivers/TestDriver066/package-lock.json
@@ -2264,7 +2264,7 @@
     "node_modules/@heap/react-native-heap": {
       "version": "0.22.4",
       "resolved": "file:../../heap-react-native-heap-0.22.4.tgz",
-      "integrity": "sha512-w2VWGkifa9FFZ/R+Bl+eBRz8q8FmhBd+V7/9rKIvqfkIN8XCT1jqvunSQL3sfqSAv2acZJcgcMaWJA6lSYi8WQ==",
+      "integrity": "sha512-p2hI3vumj6nmsmqKdoMyeBN8eBGJrBi3TIBbAW0HF2eqow1mYckQ5YRM85G1OLbz/BgJYmns8bnBlkMT68xsWA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -18784,7 +18784,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.22.4.tgz",
-      "integrity": "sha512-w2VWGkifa9FFZ/R+Bl+eBRz8q8FmhBd+V7/9rKIvqfkIN8XCT1jqvunSQL3sfqSAv2acZJcgcMaWJA6lSYi8WQ==",
+      "integrity": "sha512-p2hI3vumj6nmsmqKdoMyeBN8eBGJrBi3TIBbAW0HF2eqow1mYckQ5YRM85G1OLbz/BgJYmns8bnBlkMT68xsWA==",
       "requires": {
         "@babel/core": "^7.16.0",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -7,10 +7,13 @@ Pod::Spec.new do |s|
   s.name = "react-native-heap"
   s.version = package[:version]
   s.summary = package[:description]
-  s.license = { type: "MIT" }
+  s.license = { :type => "MIT" }
   s.author = package[:author]
   s.homepage = package[:homepage]
-  s.source = { path => '.' }
+  s.source = {
+    :git => "https://github.com/heap/react-native-heap.git",
+    :tag => "#{s.version}"
+  }
   s.source_files = "ios/**/*.{h,m}"
   s.platform = :ios, "10.0"
 


### PR DESCRIPTION
[HEAP-48203](https://heapinc.atlassian.net/browse/HEAP-48203)

## Description

Reported in #400, the podspec was generating a new checksum on different devices.  The issue is that we were using `path => '.'` instead of `:path => '.'`, which caused the `path` variable to expand as a key.

I've updated to the source repository to match what the modern template does.  It doesn't affect behavior, since `source` is ignored for local podspecs.

## Test Plan

Ran the iOS detox tests.

## Checklist
- [x] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated

fixes #400

[HEAP-48203]: https://heapinc.atlassian.net/browse/HEAP-48203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ