### PR TITLE
[HEAP-49278] Fix capture when React Navigation rootState is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue that prevents events from being sent when the navigator is not initialized
+
 ## [0.22.5] - 2023-09-26
 
 ### Fixed

--- a/js/util/__tests__/navigationUtil.test.ts
+++ b/js/util/__tests__/navigationUtil.test.ts
@@ -1,0 +1,96 @@
+import NavigationUtil from '../navigationUtil';
+
+describe('Navigation utilities', () => {
+  describe('no ref', () => {
+    describe('getScreenPropsForCurrentRoute', () => {
+      beforeEach(() => {
+        NavigationUtil.setNavigationRef(undefined);
+      });
+      it('returns null', () => {
+        expect(NavigationUtil.getScreenPropsForCurrentRoute()).toBeNull();
+      });
+    });
+  });
+
+  describe('react-navigation v5+', () => {
+    let navigationRef: any;
+    beforeEach(() => {
+      navigationRef = {
+        getRootState: jest.fn(),
+      };
+      NavigationUtil.setNavigationRef(navigationRef);
+    });
+
+    describe('getScreenPropsForCurrentRoute', () => {
+      it('returns null if the root state is undefined', () => {
+        expect(NavigationUtil.getScreenPropsForCurrentRoute()).toBeNull();
+      });
+
+      it('returns the correct screen props for a single route', () => {
+        navigationRef.getRootState.mockReturnValue({
+          index: 0,
+          routes: [{ name: 'Home' }],
+        });
+        expect(NavigationUtil.getScreenPropsForCurrentRoute()).toEqual({
+          screen_path: 'Home',
+          screen_name: 'Home',
+        });
+      });
+
+      it('returns the correct screen props for a nested route', () => {
+        navigationRef.getRootState.mockReturnValue({
+          index: 0,
+          routes: [
+            { name: 'Home', state: { index: 0, routes: [{ name: 'Feed' }] } },
+          ],
+        });
+        expect(NavigationUtil.getScreenPropsForCurrentRoute()).toEqual({
+          screen_path: 'Home::Feed',
+          screen_name: 'Feed',
+        });
+      });
+
+      it('returns the correct screen props for multiple routes', () => {
+        navigationRef.getRootState.mockReturnValue({
+          index: 1,
+          routes: [{ name: 'Home' }, { name: 'Settings' }],
+        });
+        expect(NavigationUtil.getScreenPropsForCurrentRoute()).toEqual({
+          screen_path: 'Settings',
+          screen_name: 'Settings',
+        });
+      });
+
+      it('returns the correct screen props for multiple routes, taking into account the index', () => {
+        navigationRef.getRootState.mockReturnValue({
+          index: 1,
+          routes: [{ name: 'Home' }, { name: 'Settings' }, { name: 'Profile' }],
+        });
+        expect(NavigationUtil.getScreenPropsForCurrentRoute()).toEqual({
+          screen_path: 'Settings',
+          screen_name: 'Settings',
+        });
+      });
+
+      it('returns the correct screen props for multiple nested routes', () => {
+        navigationRef.getRootState.mockReturnValue({
+          index: 1,
+          routes: [
+            { name: 'Profile' },
+            {
+              name: 'Home',
+              state: {
+                index: 1,
+                routes: [{ name: 'Feed' }, { name: 'Messages' }],
+              },
+            },
+          ],
+        });
+        expect(NavigationUtil.getScreenPropsForCurrentRoute()).toEqual({
+          screen_path: 'Home::Messages',
+          screen_name: 'Messages',
+        });
+      });
+    });
+  });
+});

--- a/js/util/navigationUtil.ts
+++ b/js/util/navigationUtil.ts
@@ -15,7 +15,9 @@ export default class NavigationUtil {
       rootState = this.heapNavRef.state.nav;
     } else if (this.heapNavRef && this.heapNavRef.getRootState) {
       rootState = this.heapNavRef.getRootState();
-    } else {
+    }
+
+    if (rootState == null) {
       return null;
     }
 


### PR DESCRIPTION
## Description
Fixes #366

In some cases, react-navigation's `getRootState()` can return `undefined`, as documented [here](https://reactnavigation.org/docs/navigation-container/#getrootstate) and [here](https://reactnavigation.org/docs/navigating-without-navigation-prop/#handling-initialization). This was being passed to `getActiveRouteProps()`, causing it to throw: `Cannot read property 'routes' of undefined`

## Test Plan
We applied this change as a patch in our app first, and confirmed it removes the error and successfully sends events. I also added some unit tests for this behaviour here.

## Checklist
- [x] Detox tests pass
    - They failed to builld for me. I don't expect my changes to affect any of those tests though.
- [x] If this is a bugfix/feature, the changelog has been updated
