### PR TITLE
[HEAP-49279] Make compatible with `use_frameworks!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed issue that prevents events from being sent when the navigator is not initialized
+- Fixed issue that prevents events from being sent when the navigator is not initialized.
+- Fixed linking and auto-initialization when using `use_frameworks!`.
 
 ## [0.22.5] - 2023-09-26
 

--- a/integration-tests/drivers/TestDriver063/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver063/ios/Podfile.lock
@@ -188,7 +188,8 @@ PODS:
   - React-jsinspector (0.63.5)
   - react-native-heap (0.22.5):
     - Heap (~> 9.0)
-    - React
+    - React-Core
+    - React-CoreModules
   - react-native-safe-area-context (3.3.2):
     - React-Core
   - React-RCTActionSheet (0.63.5):
@@ -381,7 +382,7 @@ SPEC CHECKSUMS:
   React-jsi: 7d908b17758178b076a05a254523f1a4227b53d2
   React-jsiexecutor: e06a32e42affb2bd89e4c8369349b5fcf787710c
   React-jsinspector: fdbc08866b34ae8e1b788ea1cbd9f9d1ca2aa3d6
-  react-native-heap: cce6c418bba7663652e27b55f884131622edf7cc
+  react-native-heap: c819b7f1b8cc5fda3b15b913902545044d043bff
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-RCTActionSheet: e911b99f0d6fa7711ffc2f62d236b12a32771835
   React-RCTAnimation: ad8b853170a059faf31d6add34f67d22391bbe01
@@ -400,4 +401,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 390006146a19c973c8fd37d495b45b5081c96a93
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.13.0

--- a/integration-tests/drivers/TestDriver063/package-lock.json
+++ b/integration-tests/drivers/TestDriver063/package-lock.json
@@ -2405,7 +2405,7 @@
     "node_modules/@heap/react-native-heap": {
       "version": "0.22.5",
       "resolved": "file:../../heap-react-native-heap-0.22.5.tgz",
-      "integrity": "sha512-g+l+iE4KBS6aEB7G1JCLnJGBv6bnw7OT34f4ghx+/qpzyzcr+KoIWxH8aN1v/KrxsfK0irZjMT00EDxEnL3/MQ==",
+      "integrity": "sha512-Gi0lUBnrjVIQJchw01uqz/Q3XW26uXFUitMn7PU/dGngA+3CjO7W96mWVnFS0eYbejEGSaEOI+dtTRDWaaiCxQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -24394,7 +24394,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.22.5.tgz",
-      "integrity": "sha512-g+l+iE4KBS6aEB7G1JCLnJGBv6bnw7OT34f4ghx+/qpzyzcr+KoIWxH8aN1v/KrxsfK0irZjMT00EDxEnL3/MQ==",
+      "integrity": "sha512-Gi0lUBnrjVIQJchw01uqz/Q3XW26uXFUitMn7PU/dGngA+3CjO7W96mWVnFS0eYbejEGSaEOI+dtTRDWaaiCxQ==",
       "requires": {
         "@babel/core": "^7.16.0",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/integration-tests/drivers/TestDriver063/package-lock.json
+++ b/integration-tests/drivers/TestDriver063/package-lock.json
@@ -2405,7 +2405,7 @@
     "node_modules/@heap/react-native-heap": {
       "version": "0.22.5",
       "resolved": "file:../../heap-react-native-heap-0.22.5.tgz",
-      "integrity": "sha512-Gi0lUBnrjVIQJchw01uqz/Q3XW26uXFUitMn7PU/dGngA+3CjO7W96mWVnFS0eYbejEGSaEOI+dtTRDWaaiCxQ==",
+      "integrity": "sha512-5BxLGSp0Ui9XB9qjWfuGAWi/5VyGIAnIDhvZNYRwIoCmMBDASoERJkSr/xNcrVPrbb8uXePHKNmfTvVNSuHvxg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -24394,7 +24394,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.22.5.tgz",
-      "integrity": "sha512-Gi0lUBnrjVIQJchw01uqz/Q3XW26uXFUitMn7PU/dGngA+3CjO7W96mWVnFS0eYbejEGSaEOI+dtTRDWaaiCxQ==",
+      "integrity": "sha512-5BxLGSp0Ui9XB9qjWfuGAWi/5VyGIAnIDhvZNYRwIoCmMBDASoERJkSr/xNcrVPrbb8uXePHKNmfTvVNSuHvxg==",
       "requires": {
         "@babel/core": "^7.16.0",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/integration-tests/drivers/TestDriver066/ios/Podfile
+++ b/integration-tests/drivers/TestDriver066/ios/Podfile
@@ -3,6 +3,8 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 platform :ios, '11.0'
 
+use_frameworks!
+
 target 'TestDriver066' do
   config = use_native_modules!
 
@@ -16,12 +18,6 @@ target 'TestDriver066' do
     inherit! :complete
     # Pods for testing
   end
-
-  # Enables Flipper.
-  #
-  # Note that if you have use_frameworks! enabled, Flipper will not work and
-  # you should disable the next line.
-  use_flipper!()
 
   post_install do |installer|
     react_native_post_install(installer)

--- a/integration-tests/drivers/TestDriver066/ios/Podfile.lock
+++ b/integration-tests/drivers/TestDriver066/ios/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - boost (1.76.0)
-  - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.66.5)
   - FBReactNativeSpec (0.66.5):
@@ -10,71 +9,9 @@ PODS:
     - React-Core (= 0.66.5)
     - React-jsi (= 0.66.5)
     - ReactCommon/turbomodule/core (= 0.66.5)
-  - Flipper (0.99.0):
-    - Flipper-Folly (~> 2.6)
-    - Flipper-RSocket (~> 1.4)
-  - Flipper-Boost-iOSX (1.76.0.1.11)
-  - Flipper-DoubleConversion (3.1.7)
-  - Flipper-Fmt (7.1.7)
-  - Flipper-Folly (2.6.7):
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt (= 7.1.7)
-    - Flipper-Glog
-    - libevent (~> 2.1.12)
-    - OpenSSL-Universal (= 1.1.180)
-  - Flipper-Glog (0.3.6)
-  - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.4.3):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit (0.99.0):
-    - FlipperKit/Core (= 0.99.0)
-  - FlipperKit/Core (0.99.0):
-    - Flipper (~> 0.99.0)
-    - FlipperKit/CppBridge
-    - FlipperKit/FBCxxFollyDynamicConvert
-    - FlipperKit/FBDefines
-    - FlipperKit/FKPortForwarding
-  - FlipperKit/CppBridge (0.99.0):
-    - Flipper (~> 0.99.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.99.0):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit/FBDefines (0.99.0)
-  - FlipperKit/FKPortForwarding (0.99.0):
-    - CocoaAsyncSocket (~> 7.6)
-    - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.99.0)
-  - FlipperKit/FlipperKitLayoutHelpers (0.99.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.99.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutPlugin (0.99.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - FlipperKit/FlipperKitLayoutIOSDescriptors
-    - FlipperKit/FlipperKitLayoutTextSearchable
-    - YogaKit (~> 1.18)
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.99.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.99.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.99.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.99.0):
-    - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.99.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
   - Heap (9.1.0)
-  - libevent (2.1.12)
-  - OpenSSL-Universal (1.1.180)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -275,7 +212,8 @@ PODS:
     - glog
   - react-native-heap (0.22.5):
     - Heap (~> 9.0)
-    - React
+    - React-Core
+    - React-CoreModules
   - react-native-safe-area-context (3.3.2):
     - React-Core
   - React-perflogger (0.66.5)
@@ -345,40 +283,19 @@ PODS:
     - React-perflogger (= 0.66.5)
   - RNCMaskedView (0.1.11):
     - React
+    - React-Core
   - RNGestureHandler (1.10.3):
     - React-Core
   - RNScreens (2.18.1):
     - React-Core
+    - React-RCTImage
   - Yoga (1.14.0)
-  - YogaKit (1.18.1):
-    - Yoga (~> 1.14)
 
 DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - Flipper (= 0.99.0)
-  - Flipper-Boost-iOSX (= 1.76.0.1.11)
-  - Flipper-DoubleConversion (= 3.1.7)
-  - Flipper-Fmt (= 7.1.7)
-  - Flipper-Folly (= 2.6.7)
-  - Flipper-Glog (= 0.3.6)
-  - Flipper-PeerTalk (= 0.0.4)
-  - Flipper-RSocket (= 1.4.3)
-  - FlipperKit (= 0.99.0)
-  - FlipperKit/Core (= 0.99.0)
-  - FlipperKit/CppBridge (= 0.99.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.99.0)
-  - FlipperKit/FBDefines (= 0.99.0)
-  - FlipperKit/FKPortForwarding (= 0.99.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.99.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.99.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.99.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.99.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.99.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.99.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.99.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
@@ -415,21 +332,8 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - CocoaAsyncSocket
-    - Flipper
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt
-    - Flipper-Folly
-    - Flipper-Glog
-    - Flipper-PeerTalk
-    - Flipper-RSocket
-    - FlipperKit
     - fmt
     - Heap
-    - libevent
-    - OpenSSL-Universal
-    - YogaKit
 
 EXTERNAL SOURCES:
   boost:
@@ -505,24 +409,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
-  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: a926a9aaa3596b181972abf0f47eff3dee796222
   FBReactNativeSpec: f1141d5407f4a27c397bca5db03cc03919357b0d
-  Flipper: 30e8eeeed6abdc98edaf32af0cda2f198be4b733
-  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
-  Flipper-DoubleConversion: 57ffbe81ef95306cc9e69c4aa3aeeeeb58a6a28c
-  Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
-  Flipper-Folly: 83af37379faa69497529e414bd43fbfc7cae259a
-  Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
-  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
-  FlipperKit: d8d346844eca5d9120c17d441a2f38596e8ed2b9
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 5337263514dd6f09803962437687240c5dc39aa4
   Heap: 5cf4e3f4b2fdfdae57a619fad4cafd5a654ccc97
-  libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
   RCTRequired: 405e24508a0feed1771d48caebb85c581db53122
   RCTTypeSafety: 0654998ea6afd3dccecbf6bb379d7c10d1361a72
@@ -535,7 +427,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 50a73168582868421112609d2fb155e607e34ec8
   React-jsinspector: 953260b8580780a6e81f2a6d319a8d42fd5028d8
   React-logger: fa4ff1e9c7e115648f7c5dafb7c20822ab4f7a7e
-  react-native-heap: cce6c418bba7663652e27b55f884131622edf7cc
+  react-native-heap: c819b7f1b8cc5fda3b15b913902545044d043bff
   react-native-safe-area-context: 584dc04881deb49474363f3be89e4ca0e854c057
   React-perflogger: 169fb34f60c5fd793b370002ee9c916eba9bc4ae
   React-RCTActionSheet: 2355539e02ad5cd4b1328682ab046487e1e1e920
@@ -549,12 +441,11 @@ SPEC CHECKSUMS:
   React-RCTVibration: 96dbefca7504f3e52ff47cd0ad0826d20e3a789f
   React-runtimeexecutor: 09041c28ce04143a113eac2d357a6b06bd64b607
   ReactCommon: 8a7a138ae43c04bb8dd760935589f326ca810484
-  RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
+  RNCMaskedView: e1d73380828d21646ca3081e1bc48a3119c91411
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
-  RNScreens: f7ad633b2e0190b77b6a7aab7f914fad6f198d8d
+  RNScreens: b0ec38b447437700797cb6a86378361ddfe5a7e3
   Yoga: b316a990bb6d115afa1b436b5626ac7c61717d17
-  YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 6cc3d7c3a617e70e126d330b89d7c4695a465439
+PODFILE CHECKSUM: caada0da8802f9bb90d0ad2e29a03b2d5234824a
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.13.0

--- a/integration-tests/drivers/TestDriver066/ios/TestDriver066.xcodeproj/project.pbxproj
+++ b/integration-tests/drivers/TestDriver066/ios/TestDriver066.xcodeproj/project.pbxproj
@@ -9,11 +9,9 @@
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* TestDriver066Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* TestDriver066Tests.m */; };
 		0E4F4AA2A3DC4CFDAD6AC3CF /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C7ED9DAFB3EB4B159C44CB3C /* Ionicons.ttf */; };
-		127E7A2F9B144D821E17576D /* libPods-TestDriver066.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C04CE856694441408DEA2BE9 /* libPods-TestDriver066.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		1CC85AFF7342D9C44E4D321B /* libPods-TestDriver066-TestDriver066Tests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F4142CDFAB1D119D4A2D5D24 /* libPods-TestDriver066-TestDriver066Tests.a */; };
 		36DBA73AE80D47DDA9D9ED4D /* FontAwesome5_Solid.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 9A6F505BC83849DB8DF186AE /* FontAwesome5_Solid.ttf */; };
 		3BAFCA4FB9B742308DB7B9F4 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CC3ABF972177476589144FF1 /* FontAwesome.ttf */; };
 		4259582AB43645EEB5BF1EFC /* Roboto_medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C169B275BA7243DAB2DFAF7A /* Roboto_medium.ttf */; };
@@ -23,6 +21,7 @@
 		7F6373F12FA14674B58DC2F7 /* Roboto.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 972B4F2938EA452B91011E99 /* Roboto.ttf */; };
 		816FC4DF66804668AAED7DDB /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F2CF4303F4FE4985BE93138B /* EvilIcons.ttf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		945E68EF1197702F9560FA01 /* Pods_TestDriver066_TestDriver066Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 13FE41B9FD4BF6780EF8ABFE /* Pods_TestDriver066_TestDriver066Tests.framework */; };
 		A1CD0BED52224A36A3F2BBD2 /* FontAwesome5_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 76E90FA19DF24533AF44B757 /* FontAwesome5_Regular.ttf */; };
 		AA86BB9D91DB4B6CB6FFD038 /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B159A99ABD574D4E9921A55D /* MaterialCommunityIcons.ttf */; };
 		B69ECE15BA324334A1C1A311 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A0B37BDE89DB470EB0779E2A /* Entypo.ttf */; };
@@ -33,6 +32,7 @@
 		DD50CDC736CB48D0BEEA17CD /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4046D8F93082453ABECAF5B5 /* SimpleLineIcons.ttf */; };
 		E2E88E8005B44045B6B309AA /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4B4223ABB39C4B17A3F7450F /* Foundation.ttf */; };
 		E2F074BFA239429D879DCC3A /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 997B2AD58AFD4363913234C3 /* Zocial.ttf */; };
+		F2B2F237E052E932D60A3824 /* Pods_TestDriver066.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB445C43A040BDB7D9CEEE10 /* Pods_TestDriver066.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +55,7 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = TestDriver066/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = TestDriver066/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = TestDriver066/main.m; sourceTree = "<group>"; };
+		13FE41B9FD4BF6780EF8ABFE /* Pods_TestDriver066_TestDriver066Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestDriver066_TestDriver066Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4046D8F93082453ABECAF5B5 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/native-base/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
 		4B4223ABB39C4B17A3F7450F /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/native-base/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
 		4FD6E62E5D1D49CD94368EA4 /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/native-base/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
@@ -73,15 +74,14 @@
 		9FC4CC136EBE4273B99BB700 /* FontAwesome5_Brands.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Brands.ttf; path = "../node_modules/native-base/Fonts/FontAwesome5_Brands.ttf"; sourceTree = "<group>"; };
 		A0B37BDE89DB470EB0779E2A /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/native-base/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
 		B159A99ABD574D4E9921A55D /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialCommunityIcons.ttf; path = "../node_modules/native-base/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
-		C04CE856694441408DEA2BE9 /* libPods-TestDriver066.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestDriver066.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C169B275BA7243DAB2DFAF7A /* Roboto_medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = Roboto_medium.ttf; path = "../node_modules/native-base/Fonts/Roboto_medium.ttf"; sourceTree = "<group>"; };
 		C4615D64650849A1B93498FF /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/native-base/Fonts/Feather.ttf"; sourceTree = "<group>"; };
 		C7ED9DAFB3EB4B159C44CB3C /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/native-base/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
 		CC3ABF972177476589144FF1 /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/native-base/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
+		EB445C43A040BDB7D9CEEE10 /* Pods_TestDriver066.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestDriver066.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		F2CF4303F4FE4985BE93138B /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/native-base/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		F3D323E4926A4D7B83FA7795 /* Fontisto.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = Fontisto.ttf; path = "../node_modules/native-base/Fonts/Fontisto.ttf"; sourceTree = "<group>"; };
-		F4142CDFAB1D119D4A2D5D24 /* libPods-TestDriver066-TestDriver066Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TestDriver066-TestDriver066Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,7 +89,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1CC85AFF7342D9C44E4D321B /* libPods-TestDriver066-TestDriver066Tests.a in Frameworks */,
+				945E68EF1197702F9560FA01 /* Pods_TestDriver066_TestDriver066Tests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -97,7 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				127E7A2F9B144D821E17576D /* libPods-TestDriver066.a in Frameworks */,
+				F2B2F237E052E932D60A3824 /* Pods_TestDriver066.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,8 +138,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				C04CE856694441408DEA2BE9 /* libPods-TestDriver066.a */,
-				F4142CDFAB1D119D4A2D5D24 /* libPods-TestDriver066-TestDriver066Tests.a */,
+				EB445C43A040BDB7D9CEEE10 /* Pods_TestDriver066.framework */,
+				13FE41B9FD4BF6780EF8ABFE /* Pods_TestDriver066_TestDriver066Tests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -227,7 +227,6 @@
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
 				3DA51A26E9B554B0E33CC3CF /* [CP] Embed Pods Frameworks */,
-				70EA39548BF47B588E7885CB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -250,7 +249,6 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				7298A8AAC44C46E6FE9A10B2 /* [CP] Embed Pods Frameworks */,
-				AE61EF1FE2F50CBCCE2FDACD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -389,23 +387,6 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestDriver066-TestDriver066Tests/Pods-TestDriver066-TestDriver066Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		70EA39548BF47B588E7885CB /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TestDriver066-TestDriver066Tests/Pods-TestDriver066-TestDriver066Tests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TestDriver066-TestDriver066Tests/Pods-TestDriver066-TestDriver066Tests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestDriver066-TestDriver066Tests/Pods-TestDriver066-TestDriver066Tests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		7298A8AAC44C46E6FE9A10B2 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -421,23 +402,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestDriver066/Pods-TestDriver066-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AE61EF1FE2F50CBCCE2FDACD /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TestDriver066/Pods-TestDriver066-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-TestDriver066/Pods-TestDriver066-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TestDriver066/Pods-TestDriver066-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		EF9D985D3152BC849E251182 /* [CP] Check Pods Manifest.lock */ = {

--- a/integration-tests/drivers/TestDriver066/package-lock.json
+++ b/integration-tests/drivers/TestDriver066/package-lock.json
@@ -2264,7 +2264,7 @@
     "node_modules/@heap/react-native-heap": {
       "version": "0.22.5",
       "resolved": "file:../../heap-react-native-heap-0.22.5.tgz",
-      "integrity": "sha512-g+l+iE4KBS6aEB7G1JCLnJGBv6bnw7OT34f4ghx+/qpzyzcr+KoIWxH8aN1v/KrxsfK0irZjMT00EDxEnL3/MQ==",
+      "integrity": "sha512-Gi0lUBnrjVIQJchw01uqz/Q3XW26uXFUitMn7PU/dGngA+3CjO7W96mWVnFS0eYbejEGSaEOI+dtTRDWaaiCxQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -18784,7 +18784,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.22.5.tgz",
-      "integrity": "sha512-g+l+iE4KBS6aEB7G1JCLnJGBv6bnw7OT34f4ghx+/qpzyzcr+KoIWxH8aN1v/KrxsfK0irZjMT00EDxEnL3/MQ==",
+      "integrity": "sha512-Gi0lUBnrjVIQJchw01uqz/Q3XW26uXFUitMn7PU/dGngA+3CjO7W96mWVnFS0eYbejEGSaEOI+dtTRDWaaiCxQ==",
       "requires": {
         "@babel/core": "^7.16.0",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/integration-tests/drivers/TestDriver066/package-lock.json
+++ b/integration-tests/drivers/TestDriver066/package-lock.json
@@ -2264,7 +2264,7 @@
     "node_modules/@heap/react-native-heap": {
       "version": "0.22.5",
       "resolved": "file:../../heap-react-native-heap-0.22.5.tgz",
-      "integrity": "sha512-Gi0lUBnrjVIQJchw01uqz/Q3XW26uXFUitMn7PU/dGngA+3CjO7W96mWVnFS0eYbejEGSaEOI+dtTRDWaaiCxQ==",
+      "integrity": "sha512-5BxLGSp0Ui9XB9qjWfuGAWi/5VyGIAnIDhvZNYRwIoCmMBDASoERJkSr/xNcrVPrbb8uXePHKNmfTvVNSuHvxg==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.0",
@@ -18784,7 +18784,7 @@
     },
     "@heap/react-native-heap": {
       "version": "file:../../heap-react-native-heap-0.22.5.tgz",
-      "integrity": "sha512-Gi0lUBnrjVIQJchw01uqz/Q3XW26uXFUitMn7PU/dGngA+3CjO7W96mWVnFS0eYbejEGSaEOI+dtTRDWaaiCxQ==",
+      "integrity": "sha512-5BxLGSp0Ui9XB9qjWfuGAWi/5VyGIAnIDhvZNYRwIoCmMBDASoERJkSr/xNcrVPrbb8uXePHKNmfTvVNSuHvxg==",
       "requires": {
         "@babel/core": "^7.16.0",
         "babel-plugin-add-react-displayname": "0.0.5",

--- a/integration-tests/drivers/TestDriver066/patches/@react-native-community+masked-view+0.1.11.patch
+++ b/integration-tests/drivers/TestDriver066/patches/@react-native-community+masked-view+0.1.11.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/@react-native-community/masked-view/RNCMaskedView.podspec b/node_modules/@react-native-community/masked-view/RNCMaskedView.podspec
+index 8c3849e..e04a435 100644
+--- a/node_modules/@react-native-community/masked-view/RNCMaskedView.podspec
++++ b/node_modules/@react-native-community/masked-view/RNCMaskedView.podspec
+@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
+   s.source_files  = "ios/**/*.{h,m}"
+ 
+   s.dependency 'React'
++  s.dependency 'React-Core'
+ end

--- a/integration-tests/drivers/TestDriver066/patches/react-native-screens+2.18.1.patch
+++ b/integration-tests/drivers/TestDriver066/patches/react-native-screens+2.18.1.patch
@@ -1,0 +1,11 @@
+diff --git a/node_modules/react-native-screens/RNScreens.podspec b/node_modules/react-native-screens/RNScreens.podspec
+index faf106b..acde6c9 100644
+--- a/node_modules/react-native-screens/RNScreens.podspec
++++ b/node_modules/react-native-screens/RNScreens.podspec
+@@ -20,5 +20,6 @@ Pod::Spec.new do |s|
+   s.requires_arc = true
+ 
+   s.dependency "React-Core"
++  s.dependency "React-RCTImage"
+ end
+ 

--- a/ios/HeapSettings.bundle/generate_settings.rb
+++ b/ios/HeapSettings.bundle/generate_settings.rb
@@ -20,8 +20,13 @@ HEAP_CONFIG_FILENAME = 'heap.config.json'
 # are substituted, so the plist looks unchanged. This is fixed (hackily) for the second run onwards by
 # modifying the post-copy version of the `HeapSettings` bundle directly (APP_DIRECTORY), before
 # it's copied over to a device/simulator.
-BUNDLE_DIRECTORY = File.join ENV['CONFIGURATION_BUILD_DIR'], 'HeapSettings.bundle'
-APP_DIRECTORY = Dir.glob(File.join(ENV['PODS_CONFIGURATION_BUILD_DIR'], '*.app', 'HeapSettings.bundle'))[0]
+#
+# WRAPPER_NAME is set when `use_frameworks!` is used, putting the bundle in the framework directory.
+# If not using frameworks, '.' puts it in the app's directory.
+CONFIGURATION_BUILD_DIR = ENV['CONFIGURATION_BUILD_DIR']
+WRAPPER_NAME = ENV['WRAPPER_NAME'] || '.'
+BUNDLE_DIRECTORY = File.join CONFIGURATION_BUILD_DIR, WRAPPER_NAME, 'HeapSettings.bundle'
+APP_DIRECTORY = Dir.glob(File.join(ENV['PODS_CONFIGURATION_BUILD_DIR'], '*.app', WRAPPER_NAME, 'HeapSettings.bundle'))[0]
 
 def write_heap_settings
   # `pwd` is <client_app>/ios/Pods

--- a/ios/HeapSettings.bundle/generate_settings_common.rb
+++ b/ios/HeapSettings.bundle/generate_settings_common.rb
@@ -5,6 +5,8 @@ require 'json'
 
 def perform_substitution(dir, json)
 
+  puts "Writing settings to ${dir}"
+
   set_values_simple('EnableAutocapture', 'bool', dir, json, 'enableNativeTouchEventCapture', false)
   set_values_simple('CaptureBaseUrl', 'string', dir, json, 'captureBaseUrl', '')
 

--- a/ios/RNHeapInit.m
+++ b/ios/RNHeapInit.m
@@ -11,7 +11,8 @@
 @implementation RNHeapInit
 
 + (void)load {
-    NSBundle *heapBundle = [NSBundle bundleWithPath:[[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"HeapSettings.bundle"]];
+    NSBundle *frameworkBundle = [NSBundle bundleForClass:[RNHeapInit class]];
+    NSBundle *heapBundle = [NSBundle bundleWithPath:[[frameworkBundle resourcePath] stringByAppendingPathComponent:@"HeapSettings.bundle"]];
     NSString *heapPlistPath = [heapBundle pathForResource:@"HeapSettings" ofType:@"plist"];
     NSDictionary *heapPlistData = [NSDictionary dictionaryWithContentsOfFile:heapPlistPath];
     

--- a/react-native-heap.podspec
+++ b/react-native-heap.podspec
@@ -17,7 +17,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m}"
   s.platform = :ios, "10.0"
 
-  s.dependency "React"
+  s.dependency "React-Core"
+  s.dependency "React-CoreModules"
   s.dependency "Heap", "~> 9.0"
   
   s.frameworks = "SystemConfiguration"


### PR DESCRIPTION
## Description

This adds support for podfiles containing `use_frameworks!`, employing the following three fixes:

1. The podspec explicitly requests its dependencies so framework linking succeeds.
2. The auto-init script now writes the settings to the correct location when using frameworks.
3. The auto-init code now reads the settings from the correct location when using frameworks.

## Test Plan

To support testing, the 0.66 test driver now uses frameworks while the 0.63 driver continues to use static linking.

## Checklist
- [x] Detox tests pass
- [x] If this is a bugfix/feature, the changelog has been updated
